### PR TITLE
Kapu's Body Size Bee Port

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -454,7 +454,12 @@
 
 ///Define for spawning megafauna instead of a mob for cave gen
 #define SPAWN_MEGAFAUNA "bluh bluh huge boss"
-
+//PARIAH STATION MODULAR EDIT START
+//Body sizes
+#define BODY_SIZE_NORMAL 1
+#define BODY_SIZE_SHORT 0.93
+#define BODY_SIZE_TALL 1.03
+//PARIAH STATION MODULAR EDIT END
 ///Squash flags. For squashable element
 
 ///Whether or not the squashing requires the squashed mob to be lying down

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -18,6 +18,8 @@ GLOBAL_LIST_EMPTY(undershirt_m)  //stores only undershirt name
 GLOBAL_LIST_EMPTY(undershirt_f)  //stores only undershirt name
 	//Socks
 GLOBAL_LIST_EMPTY(socks_list) //stores /datum/sprite_accessory/socks indexed by name
+	//Body Sizes - PARIAH STATION MODULAR EDIT
+GLOBAL_LIST_INIT(body_sizes, list("Normal" = BODY_SIZE_NORMAL, "Short" = BODY_SIZE_SHORT, "Tall" = BODY_SIZE_TALL))
 	//Lizard Bits (all datum lists indexed by name)
 GLOBAL_LIST_EMPTY(body_markings_list)
 GLOBAL_LIST_EMPTY(tails_list_lizard)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	var/default_mutation_genes[DNA_MUTATION_BLOCKS] //List of the default genes from this mutation to allow DNA Scanner highlighting
 	var/stability = 100
 	var/scrambled = FALSE //Did we take something like mutagen? In that case we cant get our genes scanned to instantly cheese all the powers.
+	var/current_body_size = BODY_SIZE_NORMAL //This is a size multiplier, it starts at "1". - PARIAH STATION MODULAR EDIT
 
 /datum/dna/New(mob/living/new_holder)
 	if(istype(new_holder))
@@ -96,6 +97,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	destination.dna.unique_features = unique_features
 	destination.dna.features = features.Copy()
 	destination.dna.real_name = real_name
+	destination.dna.update_body_size()
+ //Must come after features.Copy()
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
@@ -111,8 +114,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	new_dna.features = features.Copy()
 	new_dna.species = new species.type
 	new_dna.species.species_traits = species.species_traits
-	new_dna.real_name = real_name
-	// Mutations aren't gc managed, but they still aren't templates
+	new_dna.real_name = real_name // Mutations aren't gc managed, but they still aren't templates - PARIAH STATION EDIT
 	// Let's do a proper copy
 	for(var/datum/mutation/human/mutation in mutations)
 		new_dna.add_mutation(mutation, mutation.class, mutation.timeout)
@@ -438,7 +440,21 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	return
 
 /////////////////////////// DNA MOB-PROCS //////////////////////
+//PARIAH STATION EDIT START
+/datum/dna/proc/update_body_size()
+	if(!holder)
+		return
+	var/desired_size = GLOB.body_sizes[features["body_size"]]
 
+	if(desired_size == current_body_size)
+		return
+
+	var/change_multiplier = desired_size / current_body_size
+	var/translate = ((change_multiplier-1) * 32) * 0.5
+	holder.transform = holder.transform.Scale(change_multiplier)
+	holder.transform = holder.transform.Translate(0, translate)
+	current_body_size = desired_size
+//PARIAH STATION EDIT END
 /mob/proc/set_species(datum/species/mrace, icon_update = 1)
 	return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/slot_randomized //keeps track of round-to-round randomization of the character slot, prevents overwriting
 
 	var/list/randomise = list()
+	var/list/body_size = list()
 
 	//Quirk list
 	var/list/all_quirks = list()
@@ -489,6 +490,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 		character.update_body()
 		character.update_hair()
 		character.update_body_parts()
+
+		character.dna.update_body_size() //PARIAH STATION EDIT
 
 
 /// Returns whether the parent mob should have the random hardcore settings enabled. Assumes it has a mind.

--- a/code/modules/client/preferences/body_size
+++ b/code/modules/client/preferences/body_size
@@ -1,0 +1,14 @@
+#define USE_BODY_SIZE "Use body size"
+
+/datum/preference/choiced/body_type
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	priority = PREFERENCE_PRIORITY_BODY_TYPE
+	savefile_key = "body_size"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/body_size/init_possible_values()
+	return list(USE_BODY_SIZE, BODY_SIZE_NORMAL, BODY_SIZE_SHORT, BODY_SIZE_TALL)
+
+/datum/preference/choiced/body_type/create_default_value()
+	return USE_BODY_SIZE
+

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -307,6 +307,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Character
 	READ_FILE(S["randomise"],  randomise)
+	READ_FILE(S["body_size"],  body_size) //PARIAH MODULAR EDIT
 
 	//Load prefs
 	READ_FILE(S["job_preferences"], job_preferences)
@@ -365,6 +366,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Character
 	WRITE_FILE(S["randomise"] , randomise)
+	WRITE_FILE(S["body_size"] , body_size) //PARIAH MODULAR EDIT
 
 	//Write prefs
 	WRITE_FILE(S["job_preferences"] , job_preferences)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -60,6 +60,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/say_mod = "says"
 	///What languages this species can understand and say. Use a [language holder datum][/datum/language_holder] in this var.
 	var/species_language_holder = /datum/language_holder
+	var/list/default_features = list("body_size" = "Normal") // Default mutant bodyparts for this species. Don't forget to set one for every mutant bodypart you allow this species to have. - PARIAH MODULAR EDIT
 	/**
 	  * Visible CURRENT bodyparts that are unique to a species.
 	  * DO NOT USE THIS AS A LIST OF ALL POSSIBLE BODYPARTS AS IT WILL FUCK

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -9,6 +9,7 @@
 		TRAIT_NOHUNGER,
 		TRAIT_NOBREATH,
 	)
+	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None", "body_size" = "Normal") //PARIAH MODULAR EDIT
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
 	mutant_bodyparts = list("wings" = "None")
 	use_skintones = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -6,7 +6,7 @@
 	limbs_id = "human"
 
 	mutant_bodyparts = list("tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
-
+	default_features = list("mcolor" = "FFF", "wings" = "None", "body_size" = "Normal") //PARIAH MODULAR EDIT
 	mutantears = /obj/item/organ/ears/cat
 	mutant_organs = list(/obj/item/organ/tail/cat)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -12,6 +12,7 @@
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
 	meat = /obj/item/food/meat/slab/human/mutant/fly
 	mutanteyes = /obj/item/organ/eyes/fly
+	default_features = list("insect_type" = "housefly", "body_size" = "Normal") //PARIAH MODULAR EDIT
 	liked_food = GROSS
 	disliked_food = NONE
 	toxic_food = NONE

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -8,7 +8,7 @@
 		TRAIT_CAN_STRIP,
 		TRAIT_CAN_USE_FLIGHT_POTION,
 	)
-	mutant_bodyparts = list("wings" = "None")
+	mutant_bodyparts = list("mcolor" = "FFF", "wings" = "None", "body_size" = "Normal") //PARIAH MODULAR EDIT
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW | CLOTH

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -12,7 +12,8 @@
 		TRAIT_CAN_USE_FLIGHT_POTION,
 	)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_REPTILE
-	mutant_bodyparts = list("tail_lizard" = "Smooth", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
+	mutant_bodyparts = list("mcolor" = "0F0", "tail_lizard" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs", "body_size" = "Normal") //PARIAH MODULAR EDIT
+
 	external_organs = list(/obj/item/organ/external/horns = "None",
 		/obj/item/organ/external/frills = "None",
 		/obj/item/organ/external/snout = "Round")

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -12,6 +12,7 @@
 	)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
 	mutant_bodyparts = list("moth_markings" = "None")
+	default_features = list("moth_wings" = "Plain", "body_size" = "Normal") //PARIAH MODULAR EDIT
 	external_organs = list(/obj/item/organ/external/wings/moth = "Plain", /obj/item/organ/external/antennae = "Plain")
 	attack_verb = "slash"
 	attack_effect = ATTACK_EFFECT_CLAW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ORGINAL PR: https://github.com/shiptest-ss13/Shiptest/pull/795

Ports Kapu's limbs resize from Beestation for tall, and short characters, it looks really done simply because the sprites are locked to an appropriate sprite size that isn't too heavy on the overall sprite.

## Why It's Good For The Game

A nice way for people to customize and make their character sprite unique.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now pick body size for characters: short, normal or tall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
