### PR TITLE
SSDecay Port

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -119,6 +119,7 @@
 #define INIT_ORDER_GREYSCALE 81
 #define INIT_ORDER_VIS 80
 #define INIT_ORDER_DISCORD 78
+#define INIT_ORDER_DECAY -61 //PARIAH ADDITION
 #define INIT_ORDER_ACHIEVEMENTS 77
 #define INIT_ORDER_RESEARCH 75
 #define INIT_ORDER_STATION 74 //This is high priority because it manipulates a lot of the subsystems that will initialize after it.

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -119,7 +119,6 @@
 #define INIT_ORDER_GREYSCALE 81
 #define INIT_ORDER_VIS 80
 #define INIT_ORDER_DISCORD 78
-#define INIT_ORDER_DECAY -61 //PARIAH ADDITION
 #define INIT_ORDER_ACHIEVEMENTS 77
 #define INIT_ORDER_RESEARCH 75
 #define INIT_ORDER_STATION 74 //This is high priority because it manipulates a lot of the subsystems that will initialize after it.
@@ -158,6 +157,7 @@
 #define INIT_ORDER_SHUTTLE -21
 #define INIT_ORDER_MINOR_MAPPING -40
 #define INIT_ORDER_PATH -50
+#define INIT_ORDER_DECAY -61 //PARIAH ADDITION
 #define INIT_ORDER_EXPLOSIONS -69
 #define INIT_ORDER_STATPANELS -98
 #define INIT_ORDER_INIT_PROFILER -99 //Near the end, logs the costs of initialize

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -436,8 +436,11 @@ SUBSYSTEM_DEF(explosions)
 				SSexplosions.medturf += T
 			if(EXPLODE_LIGHT)
 				SSexplosions.lowturf += T
+		//PARIAH EDIT ADDITION
+		for(var/obj/machinery/light/iterating_light in T)
 
-
+			iterating_light.start_flickering()
+		//PARIAH EDIT END
 		if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)
 			flameturf += T
 

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -438,7 +438,6 @@ SUBSYSTEM_DEF(explosions)
 				SSexplosions.lowturf += T
 		//PARIAH EDIT ADDITION
 		for(var/obj/machinery/light/iterating_light in T)
-
 			iterating_light.start_flickering()
 		//PARIAH EDIT END
 		if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -12,7 +12,7 @@
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	flags_1 = NO_SCREENTIPS_1
-	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID
+	turf_flags = CAN_BE_DIRTY_1 /// PARIAH EDIT - Overriden in modular_pariah\modules\decay_subsystem\code\decay_turf_handling.dm
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 	canSmoothWith = list(SMOOTH_GROUP_OPEN_FLOOR, SMOOTH_GROUP_TURF_OPEN)
 

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -243,7 +243,10 @@
 	if(cell)
 		. += "Its backup power charge meter reads [round((cell.charge / cell.maxcharge) * 100, 0.1)]%."
 
-
+//PARIAH EDIT ADDITION
+	if(constant_flickering)
+		. += span_danger("The lighting ballast appears to be damaged, this could be fixed with a multitool.")
+	//PARIAH EDIT END
 
 // attack with item - insert light (if right type), otherwise try to break the light
 
@@ -254,6 +257,16 @@
 		var/obj/item/lightreplacer/replacer = tool
 		replacer.ReplaceLight(src, user)
 		return
+
+	//PARIAH EDIT ADDITION
+	if(istype(tool, /obj/item/multitool) && constant_flickering)
+		to_chat(user, span_notice("You start repairing the ballast of [src] with [tool]."))
+		if(do_after(user, 2 SECONDS, src))
+			stop_flickering()
+			to_chat(user, span_notice("You repair the ballast of [src]!"))
+		return
+
+	//PARIAH EDIT END
 
 	// attempt to insert light
 	if(istype(tool, /obj/item/light))
@@ -365,8 +378,8 @@
 // returns if the light has power /but/ is manually turned off
 // if a light is turned off, it won't activate emergency power
 /obj/machinery/light/proc/turned_off()
-	var/area/local_area = get_area(src)
-	return !local_area.lightswitch && local_area.power_light || flickering
+	var/area/A = get_area(src)
+	return !A.lightswitch && A.power_light || flickering || constant_flickering //PARIAH EDIT CHANGE
 
 // returns whether this light has power
 // true if area has power and lightswitch is on
@@ -409,10 +422,10 @@
 			if(status != LIGHT_OK)
 				break
 			on = !on
-			update(FALSE)
+			update(FALSE, TRUE) //PARIAH EDIT CHANGE
 			sleep(rand(5, 15))
 		on = (status == LIGHT_OK)
-		update(FALSE)
+		update(FALSE, TRUE) //PARIAH EDIT CHANGE
 		. = TRUE //did we actually flicker?
 	flickering = FALSE
 

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -243,7 +243,7 @@
 	if(cell)
 		. += "Its backup power charge meter reads [round((cell.charge / cell.maxcharge) * 100, 0.1)]%."
 
-//PARIAH EDIT ADDITION
+	//PARIAH EDIT ADDITION
 	if(constant_flickering)
 		. += span_danger("The lighting ballast appears to be damaged, this could be fixed with a multitool.")
 	//PARIAH EDIT END
@@ -378,8 +378,8 @@
 // returns if the light has power /but/ is manually turned off
 // if a light is turned off, it won't activate emergency power
 /obj/machinery/light/proc/turned_off()
-	var/area/A = get_area(src)
-	return !A.lightswitch && A.power_light || flickering || constant_flickering //PARIAH EDIT CHANGE
+	var/area/local_area = get_area(src)
+	return !local_area.lightswitch && local_area.power_light || flickering || constant_flickering //PARIAH EDIT CHANGE
 
 // returns whether this light has power
 // true if area has power and lightswitch is on

--- a/modular_pariah/master_files/code/controllers/configuration/entries/pariah_config_entries.dm
+++ b/modular_pariah/master_files/code/controllers/configuration/entries/pariah_config_entries.dm
@@ -1,0 +1,3 @@
+
+// To turn off SSDecay based on a config. You're welcome.
+/datum/config_entry/flag/ssdecay_disabled

--- a/modular_pariah/master_files/config/pariah/pariah_config.txt
+++ b/modular_pariah/master_files/config/pariah/pariah_config.txt
@@ -1,0 +1,3 @@
+
+## Toggles off SSDecay when uncommented, HIGHLY recommended for map test-merges, to avoid giving it a bad first impression.
+#SSDECAY_DISABLED

--- a/modular_pariah/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_pariah/modules/decay_subsystem/code/decaySS.dm
@@ -25,8 +25,18 @@ SUBSYSTEM_DEF(decay)
 	var/severity_modifier = 1
 
 /datum/controller/subsystem/decay/Initialize()
+	if(CONFIG_GET(flag/ssdecay_disabled))
+		message_admins("SSDecay was disabled in config.")
+		log_world("SSDecay was disabled in config.")
+		return ..()
+	// Putting this first so that it just doesn't waste time iterating through everything if it's not going to do anything anyway.
+	if(prob(50))
+		message_admins("SSDecay will not interact with this round.")
+		log_world("SSDecay will not interact with this round.")
+		return ..()
+
 	for(var/turf/iterating_turf in world)
-		if(!is_station_level(iterating_turf.z))
+		if(!(iterating_turf.turf_flags & CAN_BE_DIRTY_1))
 			continue
 		possible_turfs += iterating_turf
 
@@ -38,13 +48,10 @@ SUBSYSTEM_DEF(decay)
 	if(!possible_turfs)
 		CRASH("SSDecay had no possible turfs to use!")
 
-	if(prob(50))
-		message_admins("SSDecay will not interact with this round.")
-		return
-
 	severity_modifier = rand(1, 4)
 
 	message_admins("SSDecay severity modifier set to [severity_modifier]")
+	log_world("SSDecay severity modifier set to [severity_modifier]")
 
 	do_common()
 

--- a/modular_pariah/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_pariah/modules/decay_subsystem/code/decaySS.dm
@@ -56,6 +56,8 @@ SUBSYSTEM_DEF(decay)
 
 	do_medical()
 
+	return ..()
+
 /datum/controller/subsystem/decay/proc/do_common()
 	for(var/turf/open/floor/iterating_floor in possible_turfs)
 		if(!istype(iterating_floor, /turf/open/floor/plating))

--- a/modular_pariah/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_pariah/modules/decay_subsystem/code/decaySS.dm
@@ -1,0 +1,126 @@
+/*
+This is the decay subsystem that is run once at startup.
+These procs are incredibly expensive and should only really be run once. That's why the only run once.
+*/
+
+
+#define WALL_RUST_PERCENT_CHANCE 15
+
+#define FLOOR_DIRT_PERCENT_CHANCE 15
+#define FLOOR_BLOOD_PERCENT_CHANCE 1
+#define FLOOR_VOMIT_PERCENT_CHANCE 1
+#define FLOOR_OIL_PERCENT_CHANCE 5
+#define FLOOR_TILE_MISSING_PERCENT_CHANCE 1
+#define FLOOR_COBWEB_PERCENT_CHANCE 1
+
+#define NEST_PERCENT_CHANCE 1
+
+#define LIGHT_FLICKER_PERCENT_CHANCE 10
+
+SUBSYSTEM_DEF(decay)
+	name = "Decay System"
+	flags = SS_NO_FIRE
+	init_order = INIT_ORDER_DECAY
+
+	var/list/possible_turfs = list()
+	var/list/possible_areas = list()
+	var/severity_modifier = 1
+
+/datum/controller/subsystem/decay/Initialize()
+	for(var/turf/iterating_turf in world)
+		if(!is_station_level(iterating_turf.z))
+			continue
+		possible_turfs += iterating_turf
+
+	for(var/area/iterating_area in world)
+		if(!is_station_level(iterating_area.z))
+			continue
+		possible_areas += iterating_area
+
+	if(!possible_turfs)
+		CRASH("SSDecay had no possible turfs to use!")
+
+	if(prob(50))
+		message_admins("SSDecay will not interact with this round.")
+		return
+
+	severity_modifier = rand(1, 4)
+
+	message_admins("SSDecay severity modifier set to [severity_modifier]")
+
+	do_common()
+
+	do_maintenance()
+
+	do_engineering()
+
+	do_medical()
+
+/datum/controller/subsystem/decay/proc/do_common()
+	for(var/turf/open/floor/iterating_floor in possible_turfs)
+		if(!istype(iterating_floor, /turf/open/floor/plating))
+			if(prob(FLOOR_TILE_MISSING_PERCENT_CHANCE * severity_modifier) && prob(60))
+				iterating_floor.break_tile_to_plating()
+
+		if(prob(FLOOR_DIRT_PERCENT_CHANCE * severity_modifier))
+			new /obj/effect/decal/cleanable/dirt(iterating_floor)
+
+		if(prob(FLOOR_DIRT_PERCENT_CHANCE * severity_modifier))
+			new /obj/effect/decal/cleanable/dirt(iterating_floor)
+
+	for(var/turf/closed/iterating_wall in possible_turfs)
+		if(prob(WALL_RUST_PERCENT_CHANCE * severity_modifier))
+			var/mutable_appearance/rust = mutable_appearance(iterating_wall.icon, "rust")
+			iterating_wall.add_overlay(rust)
+
+/datum/controller/subsystem/decay/proc/do_maintenance()
+	for(var/area/maintenance/iterating_maintenance in possible_areas)
+		for(var/turf/open/iterating_floor in iterating_maintenance)
+			if(prob(FLOOR_BLOOD_PERCENT_CHANCE * severity_modifier))
+				var/obj/effect/decal/cleanable/blood/spawned_blood = new (iterating_floor)
+				spawned_blood.dry()
+				if(!iterating_floor.Enter(spawned_blood))
+					qdel(spawned_blood) //No blood under windows.
+
+			if(prob(FLOOR_COBWEB_PERCENT_CHANCE * severity_modifier))
+				var/obj/structure/spider/stickyweb/spawned_web = new (iterating_floor)
+				if(!iterating_floor.Enter(spawned_web))
+					qdel(spawned_web)
+
+
+		for(var/obj/machinery/light/iterating_light in iterating_maintenance)
+			if(prob(LIGHT_FLICKER_PERCENT_CHANCE))
+				iterating_light.start_flickering()
+
+/datum/controller/subsystem/decay/proc/do_engineering()
+	for(var/area/engineering/iterating_engineering in possible_areas)
+		for(var/turf/open/iterating_floor in iterating_engineering)
+			if(prob(FLOOR_BLOOD_PERCENT_CHANCE * severity_modifier))
+				var/obj/effect/decal/cleanable/blood/spawned_blood = new (iterating_floor)
+				spawned_blood.dry()
+				if(!iterating_floor.Enter(spawned_blood))
+					qdel(spawned_blood)
+
+			if(prob(FLOOR_OIL_PERCENT_CHANCE * severity_modifier))
+				var/obj/effect/decal/cleanable/oil/spawned_oil = new (iterating_floor)
+				if(!iterating_floor.Enter(spawned_oil))
+					qdel(spawned_oil)
+
+/datum/controller/subsystem/decay/proc/do_medical()
+	for(var/area/medical/iterating_medical in possible_areas)
+		for(var/turf/open/iterating_floor in iterating_medical)
+			if(prob(FLOOR_BLOOD_PERCENT_CHANCE * severity_modifier))
+				var/obj/effect/decal/cleanable/blood/spawned_blood = new (iterating_floor)
+				spawned_blood.dry()
+				if(!iterating_floor.Enter(spawned_blood))
+					qdel(spawned_blood)
+
+			if(prob(FLOOR_VOMIT_PERCENT_CHANCE * severity_modifier))
+				var/obj/effect/decal/cleanable/vomit/spawned_vomit = new (iterating_floor)
+				if(!iterating_floor.Enter(spawned_vomit))
+					qdel(spawned_vomit)
+
+		if(is_type_in_list(iterating_medical, list(/area/medical/coldroom, /area/medical/morgue, /area/medical/psychology)))
+			for(var/obj/machinery/light/iterating_light in iterating_medical)
+				if(prob(LIGHT_FLICKER_PERCENT_CHANCE))
+					iterating_light.start_flickering()

--- a/modular_pariah/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_pariah/modules/decay_subsystem/code/decaySS.dm
@@ -13,8 +13,6 @@ These procs are incredibly expensive and should only really be run once. That's 
 #define FLOOR_TILE_MISSING_PERCENT_CHANCE 1
 #define FLOOR_COBWEB_PERCENT_CHANCE 1
 
-#define NEST_PERCENT_CHANCE 1
-
 #define LIGHT_FLICKER_PERCENT_CHANCE 10
 
 SUBSYSTEM_DEF(decay)

--- a/modular_pariah/modules/decay_subsystem/code/decay_turf_handling.dm
+++ b/modular_pariah/modules/decay_subsystem/code/decay_turf_handling.dm
@@ -1,0 +1,14 @@
+/// A turf flag, much higher than what the other turf flags are at because I don't want to cause conflicts by accident.
+#define CAN_DECAY_BREAK_1 (1<<23)
+
+/turf/open/floor
+	turf_flags = CAN_BE_DIRTY_1 | CAN_DECAY_BREAK_1 // We do it this way because we can then easily pick what we don't want to be broken.
+
+/turf/open/floor/plating
+	turf_flags = CAN_BE_DIRTY_1 /// No breaking the plating
+
+/turf/open/floor/glass
+	turf_flags = CAN_BE_DIRTY_1 /// No breaking the glass (doesn't leave plating behind)
+
+/turf/open/floor/plating/asteroid
+	turf_flags = NONE /// They shouldn't break and they shouldn't be dirty, it's literally already a dirty turf.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4402,4 +4402,5 @@
 #include "modular_pariah\modules\combat_indicator\code\combat_indicator.dm"
 #include "modular_pariah\modules\gunsafety\code\gun_safety.dm"
 #include "modular_pariah\modules\large_doors\code\large_doors.dm"
+#include "modular_pariah\modules\decay_subsystem\code\decaySS.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4337,6 +4337,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "modular_pariah\master_files\code\controllers\configuration\entries\pariah_config_entries.dm"
 #include "modular_pariah\master_files\code\datums\components\fullauto.dm"
 #include "modular_pariah\master_files\code\game\sound.dm"
 #include "modular_pariah\master_files\code\modules\mob\living\emote_popup.dm"
@@ -4403,4 +4404,5 @@
 #include "modular_pariah\modules\gunsafety\code\gun_safety.dm"
 #include "modular_pariah\modules\large_doors\code\large_doors.dm"
 #include "modular_pariah\modules\decay_subsystem\code\decaySS.dm"
+#include "modular_pariah\modules\decay_subsystem\code\decay_turf_handling.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/6480

Ever wanted to work on a station that felt dirty, used, and like a deathtrap in space? Well, SSDecay adds a bit of flavor to the game by rusting walls, dirtying floors, and messing with the lights. To truly add to the spessmen feel on working in a research station that probably has been fixed more than a thousand times and signifies that it can also be your tomb.

![7ZQMXit8AM](https://user-images.githubusercontent.com/62493359/159142729-d5eb709c-7423-4bf4-baea-110f86f342a2.png)


## Why It's Good For The Game

Adds a bit of flavor to the station, dirty place with a lot of history and a bit of sadness is always nice to the atmosphere, plus it gives the janitor something to do round start and a reason for engineering to fix walls and shit if they want.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: A subsystem has been added that allows the station to start dirty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
