### PR TITLE
Fixes the build system not detecting changes in `/modular_pariah`

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -69,6 +69,7 @@ export const DmTarget = new Juke.Target({
     'html/**',
     'icons/**',
     'interface/**',
+    'modular_pariah/**', //PARIAH EDIT
     `${DME_NAME}.dme`,
   ],
   outputs: [


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a line in `tools/build/build.js` for the `/modular_pariah` folder, so that any code changes made in there get detected by the build system.
Looking into it further it seems like [Skyrat](https://github.com/Skyrat-SS13/Skyrat-tg/blob/20f1aded5d8d8bec15be67dfd3db963ec248884b/tools/build/build.js#L72) had to do this as well, so hopefully this should fix the whole `Skipping 'dm' (up to date)` issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Compiling actually works.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Fixed juke build not detecting code changes in the `modular_pariah` folder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

*first PR in 5 months woo!*