### PR TITLE
Light tweaks - lighting related ports

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -108,8 +108,8 @@
 /obj/machinery/light/update_icon_state()
 	switch(status) // set icon_states
 		if(LIGHT_OK)
-			var/area/local_area = get_area(src)
-			if(emergency_mode || (local_area?.fire))
+			//var/area/A = get_area(src) //PARIAH EDIT REMOVAL
+			if(emergency_mode || firealarm) //PARIAH EDIT CHANGE
 				icon_state = "[base_state]_emergency"
 			else
 				icon_state = "[base_state]"
@@ -126,8 +126,11 @@
 	if(!on || status != LIGHT_OK)
 		return
 
+	/* ORIGINAL:
 	var/area/local_area = get_area(src)
 	if(emergency_mode || (local_area?.fire))
+	*/
+	if(emergency_mode || firealarm) //PARIAH EDIT END
 		. += mutable_appearance(overlay_icon, "[base_state]_emergency")
 		return
 	if(nightshift_enabled)
@@ -135,13 +138,19 @@
 		return
 	. += mutable_appearance(overlay_icon, base_state)
 
+//PARIAH EDIT ADDITION
+#define LIGHT_ON_DELAY_UPPER 3 SECONDS
+#define LIGHT_ON_DELAY_LOWER 1 SECONDS
+//PARIAH EDIT END
+
 // update the icon_state and luminosity of the light depending on its state
-/obj/machinery/light/proc/update(trigger = TRUE)
+/obj/machinery/light/proc/update(trigger = TRUE, instant = FALSE, play_sound = TRUE) //PARIAH EDIT CHANGE
 	switch(status)
 		if(LIGHT_BROKEN,LIGHT_BURNED,LIGHT_EMPTY)
 			on = FALSE
 	emergency_mode = FALSE
 	if(on)
+	/* ORIGINAL
 		var/brightness_set = brightness
 		var/power_set = bulb_power
 		var/color_set = bulb_colour
@@ -171,6 +180,17 @@
 					l_power = power_set,
 					l_color = color_set
 					)
+		*/
+		//PARIAH EDIT
+		if(instant)
+			turn_on(trigger, play_sound)
+		else if(maploaded)
+			turn_on(trigger, play_sound)
+			maploaded = FALSE
+		else if(!turning_on)
+			turning_on = TRUE
+			addtimer(CALLBACK(src, .proc/turn_on, trigger, play_sound), rand(LIGHT_ON_DELAY_LOWER, LIGHT_ON_DELAY_UPPER))
+		//PARIAH EDIT END
 	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE) && !turned_off())
 		use_power = IDLE_POWER_USE
 		emergency_mode = TRUE
@@ -190,6 +210,11 @@
 			removeStaticPower(static_power_used, AREA_USAGE_STATIC_LIGHT)
 
 	broken_sparks(start_only=TRUE)
+
+//PARIAH EDIT
+#undef LIGHT_ON_DELAY_UPPER
+#undef LIGHT_ON_DELAY_LOWER
+//PARIAH EDIT END
 
 /obj/machinery/light/update_atom_colour()
 	..()
@@ -242,11 +267,12 @@
 			. += "The [fitting] has been smashed."
 	if(cell)
 		. += "Its backup power charge meter reads [round((cell.charge / cell.maxcharge) * 100, 0.1)]%."
-
 	//PARIAH EDIT ADDITION
 	if(constant_flickering)
 		. += span_danger("The lighting ballast appears to be damaged, this could be fixed with a multitool.")
 	//PARIAH EDIT END
+
+
 
 // attack with item - insert light (if right type), otherwise try to break the light
 
@@ -265,7 +291,6 @@
 			stop_flickering()
 			to_chat(user, span_notice("You repair the ballast of [src]!"))
 		return
-
 	//PARIAH EDIT END
 
 	// attempt to insert light
@@ -385,6 +410,10 @@
 // true if area has power and lightswitch is on
 /obj/machinery/light/proc/has_power()
 	var/area/local_area = get_area(src)
+	//PARIAH EDIT ADDITION
+	if(isnull(local_area))
+		return FALSE
+	//PARIAH EDIT END
 	return local_area.lightswitch && local_area.power_light
 
 // returns whether this light has emergency power

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -108,7 +108,7 @@
 /obj/machinery/light/update_icon_state()
 	switch(status) // set icon_states
 		if(LIGHT_OK)
-			//var/area/A = get_area(src) //PARIAH EDIT REMOVAL
+			//var/area/local_area = get_area(src) //PARIAH EDIT REMOVAL
 			if(emergency_mode || firealarm) //PARIAH EDIT CHANGE
 				icon_state = "[base_state]_emergency"
 			else

--- a/modular_pariah/master_files/code/modules/power/lighting.dm
+++ b/modular_pariah/master_files/code/modules/power/lighting.dm
@@ -1,0 +1,8 @@
+//We're lowering the power of light fixtures for **mood lighting**
+/obj/machinery/light
+	bulb_colour = "#FFEEDD"
+	bulb_power = 0.75
+
+/obj/machinery/light/small
+	bulb_colour = "#FFDDBB"
+	bulb_power = 0.75

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4372,6 +4372,7 @@
 #include "modular_pariah\master_files\code\modules\client\preferences\loadout_override_preference.dm"
 #include "modular_pariah\master_files\code\modules\mob\dead\new_player\preferences_setup.dm"
 #include "modular_pariah\master_files\code\modules\mob\living\emote_popup.dm"
+#include "modular_pariah\master_files\code\modules\power\lighting.dm"
 #include "modular_pariah\master_files\code\modules\projectiles\guns\gun.dm"
 #include "modular_pariah\master_files\code\modules\projectiles\guns\ballistic\automatic.dm"
 #include "modular_pariah\modules\aesthetics\abductor\abductor.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports:
https://github.com/Skyrat-SS13/Skyrat-tg/pull/943
https://github.com/Skyrat-SS13/Skyrat-tg/pull/1536

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the lights less bright resulting in a net positive of **_aesthetics_**

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Lights now have a new sound for turning on.
add: Light switches now actually switch.
code: Lights take some time to warm up and turn on.
code: All areas now have a 50% chance to start with lights off(provided the area has a lightswitch!)
code: Lights are now dimmer by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
