### PR TITLE
Stam Crit Visual Indicator

### DIFF
--- a/code/__DEFINES/~pariah_defines/combat.dm
+++ b/code/__DEFINES/~pariah_defines/combat.dm
@@ -1,0 +1,1 @@
+#define FILTER_STAMINACRIT filter(type="drop_shadow", x=0, y=0, size=-3, color="#04080F")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -348,7 +348,7 @@
 		return FALSE
 	visible_message(span_danger("[src] manages to [cuff_break ? "break" : "remove"] [I]!"))
 	to_chat(src, span_notice("You successfully [cuff_break ? "break" : "remove"] [I]."))
-	
+
 	if(cuff_break)
 		. = !((I == handcuffed) || (I == legcuffed))
 		qdel(I)
@@ -544,6 +544,7 @@
 		REMOVE_TRAIT(src, TRAIT_INCAPACITATED, STAMINA)
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, STAMINA)
 		REMOVE_TRAIT(src, TRAIT_FLOORED, STAMINA)
+		filters -= FILTER_STAMINACRIT //PARIAH EDIT
 	else
 		return
 	update_stamina_hud()

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -17,6 +17,7 @@
 	ADD_TRAIT(src, TRAIT_INCAPACITATED, STAMINA)
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, STAMINA)
 	ADD_TRAIT(src, TRAIT_FLOORED, STAMINA)
+	filters += FILTER_STAMINACRIT //PARIAH EDIT
 	if(getStaminaLoss() < 120) // Puts you a little further into the initial stamcrit, makes stamcrit harder to outright counter with chems.
 		adjustStaminaLoss(30, FALSE)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -264,6 +264,7 @@
 #include "code\__DEFINES\research\anomalies.dm"
 #include "code\__DEFINES\~pariah_defines\baton_upgrades.dm"
 #include "code\__DEFINES\~pariah_defines\chat.dm"
+#include "code\__DEFINES\~pariah_defines\combat.dm"
 #include "code\__DEFINES\~pariah_defines\DNA.dm"
 #include "code\__DEFINES\~pariah_defines\flavor_defines.dm"
 #include "code\__DEFINES\~pariah_defines\gun.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a small visual effect when someone is in stam crit.
![dreamseeker_wl5LqEdNJf](https://user-images.githubusercontent.com/62493359/161229105-a457e71f-5328-4bff-96a7-d57c26827e2a.gif)


## Why It's Good For The Game

Useful for being able to read when someone is down, as well as QoL change.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Being put into stamcrit now gives an effect to properly show that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
