### PR TITLE
Master ERP pref no longer shows up as error

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pariah/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pariah/erp_preferences.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, FeatureToggle } from "../../base";
+
+export const master_erp_pref: FeatureToggle = {
+  name: "Show/Hide Erotic Roleplay Preferences",
+  category: "ERP",
+  description: "This shows/hides ERP preferences.",
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/71735193/163561108-5aaa72f5-b90e-4fc2-9ad5-2f73c2f79037.png)
^ this now works
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Some people might not want to see that.
Also it just showed up as an error, now it doesnt.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Master ERP preference setting now shows up correctly.
/:cl:

*the perks of an ERP-having codebase... yay*

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
