### PR TITLE
Fixes offset features (Alternative to TG)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -158,7 +158,6 @@ There are several things that need to be remembered:
 
 		var/mutable_appearance/uniform_overlay
 
-		//Change check_adjustable_clothing.dm if you change this
 		var/handled_by_bodytype = TRUE
 		var/icon_file
 		var/woman

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -184,7 +184,7 @@ There are several things that need to be remembered:
 				override_file = handled_by_bodytype ? icon_file : null
 			)
 
-		if(OFFSET_UNIFORM in dna.species.offset_features && !handled_by_bodytype)
+		if(!handled_by_bodytype && (OFFSET_UNIFORM in dna.species.offset_features))
 			uniform_overlay?.pixel_x += dna.species.offset_features[OFFSET_UNIFORM][1]
 			uniform_overlay?.pixel_y += dna.species.offset_features[OFFSET_UNIFORM][2]
 		overlays_standing[UNIFORM_LAYER] = uniform_overlay
@@ -215,7 +215,7 @@ There are several things that need to be remembered:
 
 		if(!id_overlay)
 			return
-		if(OFFSET_ID in dna.species.offset_features && !handled_by_bodytype)
+		if(!handled_by_bodytype && (OFFSET_ID in dna.species.offset_features))
 			id_overlay.pixel_x += dna.species.offset_features[OFFSET_ID][1]
 			id_overlay.pixel_y += dna.species.offset_features[OFFSET_ID][2]
 		overlays_standing[ID_LAYER] = id_overlay
@@ -259,7 +259,7 @@ There are several things that need to be remembered:
 
 		if(!gloves_overlay)
 			return
-		if(OFFSET_GLOVES in dna.species.offset_features && !handled_by_bodytype)
+		if(!handled_by_bodytype && (OFFSET_GLOVES in dna.species.offset_features))
 			gloves_overlay.pixel_x += dna.species.offset_features[OFFSET_GLOVES][1]
 			gloves_overlay.pixel_y += dna.species.offset_features[OFFSET_GLOVES][2]
 		overlays_standing[GLOVES_LAYER] = gloves_overlay
@@ -293,7 +293,7 @@ There are several things that need to be remembered:
 
 		if(!glasses_overlay)
 			return
-		if(OFFSET_GLASSES in dna.species.offset_features && !handled_by_bodytype)
+		if(!handled_by_bodytype && (OFFSET_GLASSES in dna.species.offset_features))
 			glasses_overlay.pixel_x += dna.species.offset_features[OFFSET_GLASSES][1]
 			glasses_overlay.pixel_y += dna.species.offset_features[OFFSET_GLASSES][2]
 		overlays_standing[GLASSES_LAYER] = glasses_overlay
@@ -326,7 +326,7 @@ There are several things that need to be remembered:
 
 		if(!ears_overlay)
 			return
-		if(OFFSET_EARS in dna.species.offset_features && !handled_by_bodytype)
+		if(!handled_by_bodytype && (OFFSET_EARS in dna.species.offset_features))
 			ears_overlay.pixel_x += dna.species.offset_features[OFFSET_EARS][1]
 			ears_overlay.pixel_y += dna.species.offset_features[OFFSET_EARS][2]
 		overlays_standing[EARS_LAYER] = ears_overlay
@@ -355,7 +355,7 @@ There are several things that need to be remembered:
 
 			if(!neck_overlay)
 				return
-			if(OFFSET_NECK in dna.species.offset_features && !handled_by_bodytype)
+			if(!handled_by_bodytype && (OFFSET_NECK in dna.species.offset_features))
 				neck_overlay.pixel_x += dna.species.offset_features[OFFSET_NECK][1]
 				neck_overlay.pixel_y += dna.species.offset_features[OFFSET_NECK][2]
 			overlays_standing[NECK_LAYER] = neck_overlay
@@ -396,7 +396,7 @@ There are several things that need to be remembered:
 
 		if(!shoes_overlay)
 			return
-		if(!(handled_by_bodytype) && (OFFSET_SHOES in dna.species.offset_features))
+		if(!handled_by_bodytype && (OFFSET_SHOES in dna.species.offset_features))
 			shoes_overlay.pixel_x += dna.species.offset_features[OFFSET_SHOES][1]
 			shoes_overlay.pixel_y += dna.species.offset_features[OFFSET_SHOES][2]
 		overlays_standing[SHOES_LAYER] = shoes_overlay
@@ -453,7 +453,7 @@ There are several things that need to be remembered:
 
 		if(!head_overlay)
 			return
-		if(!(handled_by_bodytype) && (OFFSET_HEAD in dna.species.offset_features))
+		if(!handled_by_bodytype && (OFFSET_HEAD in dna.species.offset_features))
 			head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]
 			head_overlay.pixel_y += dna.species.offset_features[OFFSET_HEAD][2]
 		overlays_standing[HEAD_LAYER] = head_overlay
@@ -483,7 +483,7 @@ There are several things that need to be remembered:
 
 		if(!belt_overlay)
 			return
-		if(OFFSET_BELT in dna.species.offset_features && !handled_by_bodytype)
+		if(!handled_by_bodytype && (OFFSET_BELT in dna.species.offset_features))
 			belt_overlay.pixel_x += dna.species.offset_features[OFFSET_BELT][1]
 			belt_overlay.pixel_y += dna.species.offset_features[OFFSET_BELT][2]
 		overlays_standing[BELT_LAYER] = belt_overlay
@@ -584,7 +584,7 @@ There are several things that need to be remembered:
 
 		if(!mask_overlay)
 			return
-		if((!handled_by_bodytype) && (OFFSET_FACEMASK in dna.species.offset_features))
+		if(!handled_by_bodytype && (OFFSET_FACEMASK in dna.species.offset_features))
 			mask_overlay.pixel_x += dna.species.offset_features[OFFSET_FACEMASK][1]
 			mask_overlay.pixel_y += dna.species.offset_features[OFFSET_FACEMASK][2]
 
@@ -615,7 +615,7 @@ There are several things that need to be remembered:
 
 		if(!back_overlay)
 			return
-		if((!handled_by_bodytype) && (OFFSET_BACK in dna.species.offset_features))
+		if(!handled_by_bodytype && (OFFSET_BACK in dna.species.offset_features))
 			back_overlay.pixel_x += dna.species.offset_features[OFFSET_BACK][1]
 			back_overlay.pixel_y += dna.species.offset_features[OFFSET_BACK][2]
 		overlays_standing[BACK_LAYER] = back_overlay


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some `species.offset_features` not applying properly due to ambiguous `X in list` checks.
![image](https://user-images.githubusercontent.com/57483089/166151564-8ca5ca47-b486-4a72-a29b-95c60e458a85.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Alternative to https://github.com/tgstation/tgstation/pull/66477, keeping the `handled_by_bodytype` variable since it'll likely be useful in the future for some species.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
