### PR TITLE
Adds support for character preference tooltips

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
@@ -1,6 +1,6 @@
 import { classes } from "common/react";
 import { sendAct, useBackend, useLocalState } from "../../backend";
-import { Autofocus, Box, Button, Flex, LabeledList, Popper, Stack, TrackOutsideClicks, Dropdown } from "../../components"; // PARIAH EDIT CHANGE
+import { Autofocus, Box, Button, Flex, LabeledList, Popper, Stack, TrackOutsideClicks, Dropdown, Tooltip } from "../../components";
 import { createSetPreference, PreferencesMenuData, RandomSetting } from "./data";
 import { CharacterPreview } from "./CharacterPreview";
 import { RandomizationButton } from "./RandomizationButton";
@@ -368,10 +368,23 @@ const PreferenceList = (props: {
                 );
               }
 
+              let name = feature.name;
+              if (feature.description) {
+                name = (
+                  <Tooltip content={feature.description} position="bottom-start">
+                    <Box as="span" style={{
+                      "border-bottom": "2px dotted rgba(255, 255, 255, 0.8)",
+                    }}>
+                      {name}
+                    </Box>
+                  </Tooltip>
+                );
+              }
+
               return (
                 <LabeledList.Item
                   key={featureId}
-                  label={feature.name}
+                  label={name}
                   verticalAlign="middle"
                 >
                   <Stack fill>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
@@ -1,4 +1,5 @@
 import { classes } from "common/react";
+import { InfernoNode } from "inferno";
 import { sendAct, useBackend, useLocalState } from "../../backend";
 import { Autofocus, Box, Button, Flex, LabeledList, Popper, Stack, TrackOutsideClicks, Dropdown, Tooltip } from "../../components";
 import { createSetPreference, PreferencesMenuData, RandomSetting } from "./data";
@@ -368,14 +369,14 @@ const PreferenceList = (props: {
                 );
               }
 
-              let name = feature.name;
+              let name: InfernoNode = feature.name;
               if (feature.description) {
                 name = (
                   <Tooltip content={feature.description} position="bottom-start">
                     <Box as="span" style={{
                       "border-bottom": "2px dotted rgba(255, 255, 255, 0.8)",
                     }}>
-                      {name}
+                      {name}:
                     </Box>
                   </Tooltip>
                 );


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds support for preference tooltips in the character creation screen.
This works the same way as in the game preferences menu, using the `description` argument from the .tsx definition.
<details>
<summary><b>Example:</b></summary>

```diff
export const hair_gradient: FeatureChoiced = {
  name: "Hair gradient",
  component: FeatureDropdownInput,
+  description: "New tooltip example!",
};
```
![tooltip](https://user-images.githubusercontent.com/57483089/166156879-0ec7f222-76db-408e-b8b3-f9aa79ba5d79.gif)
</details>

(Code mostly stolen from [tgui\packages\tgui\interfaces\PreferencesMenu\GamePreferencesPage.tsx](https://github.com/pariahstation/Pariah-Station/blob/6750c49b500ac92fbe902f7f8e02a0b11c1fa5b2/tgui/packages/tgui/interfaces/PreferencesMenu/GamePreferencesPage.tsx#L31-L55), but streamlined a bit.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Greater flexibility when adding character preferences, and specifically it might be useful for #506.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added support for character preference tooltips.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
