### PR TITLE
[READY] Adjusts Species Dummy Colors

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -135,7 +135,7 @@
 /datum/species/human/felinid/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.hairstyle = "Hime Cut"
 	human.hair_color = "#ffcccc" // pink
-	human.update_hair()
+	human.update_hair(TRUE)
 
 	var/obj/item/organ/ears/cat/cat_ears = human.getorgan(/obj/item/organ/ears/cat)
 	if (cat_ears)

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -19,7 +19,7 @@
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.hairstyle = "Business Hair"
 	human.hair_color = "#bb9966" // brown
-	human.update_hair()
+	human.update_hair(TRUE)
 
 /datum/species/human/get_scream_sound(mob/living/carbon/human/human)
 	if(human.gender == MALE)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -238,5 +238,5 @@ Lizard subspecies: SILVER SCALED
 	..()
 
 /datum/species/lizard/prepare_human_for_preview(mob/living/carbon/human/human)
-	human.dna.features["mcolor"] = "#6A4521"
+	human.dna.features["mcolor"] = "#f8f2a4"
 	human.update_body(TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -238,5 +238,5 @@ Lizard subspecies: SILVER SCALED
 	..()
 
 /datum/species/lizard/prepare_human_for_preview(mob/living/carbon/human/human)
-    human.dna.features["mcolor"] = "#6A4521"
-    human.update_body(TRUE)
+	human.dna.features["mcolor"] = "#6A4521"
+	human.update_body(TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -236,3 +236,7 @@ Lizard subspecies: SILVER SCALED
 
 	was_silverscale.remove_filter("silver_glint")
 	..()
+
+/datum/species/lizard/prepare_human_for_preview(mob/living/carbon/human/human)
+    human.dna.features["mcolor"] = "#6A4521"
+    human.update_body(TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -132,5 +132,5 @@
 	return to_add
 
 /datum/species/moth/prepare_human_for_preview(mob/living/carbon/human/human)
-    human.dna.features["mcolor"] = "#f4d697"
-    human.update_body(TRUE)
+	human.dna.features["mcolor"] = "#f4d697"
+	human.update_body(TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -130,3 +130,7 @@
 	)
 
 	return to_add
+
+/datum/species/moth/prepare_human_for_preview(mob/living/carbon/human/human)
+    human.dna.features["mcolor"] = "#f4d697"
+    human.update_body(TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skrell.dm
@@ -38,8 +38,8 @@
 		skrell_mob.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 
 /datum/species/skrell/prepare_human_for_preview(mob/living/carbon/human/human)
-	human.dna.features["mcolor"] = sanitize_hexcolor(COLOR_BLUE_GRAY)
-	human.update_body()
+	human.dna.features["mcolor"] = COLOR_BLUE_GRAY
+	human.update_body(TRUE)
 
 // Copper restores blood for Skrell instead of iron.
 /datum/species/skrell/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H, delta_time, times_fired)


### PR DESCRIPTION
Edits Mothmen and Skrell skintones to be more appropriate in the preview for their species, aswell as gives the species preview for humans and felinids proper hair so they aren't peeled.

## About The Pull Request

I thought that having wack lime green colors for species portraits (particularly on things like moths that looked awful) was eyebleed. So I changed it to something less eye-bleedy and adjusted lizards default skintone to a better shade since it blended too much with the active highlight state of the species selector.

## Why It's Good For The Game

Not particularly player facing but this looks infinitely better:
![image](https://user-images.githubusercontent.com/9637690/168499542-fb245281-bd4d-4d3d-b0bd-8ad97c8609a5.png)

## Changelog

:cl: Gonenoculer5
fix: Adjusts moth, skrell, and Unathi skin tones in the species dummy, and gives felinids and humans hair in their species dummy.
/:cl: