### PR TITLE
Re-adds the Deluxe Agent Card

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -22,7 +22,7 @@
 	name = "Advanced Agent Identification Card"
 	desc = "Created by Cybersun Industries to be the ultimate for field operations, this upgraded Agent ID \
 	comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
-	standard Nanotrasen access codes in one conveinent package. Now in glossy olive by default!"
+	standard Nanotrasen access codes in one conveinent package. Now in glossy black by default!"
 	item = /obj/item/card/id/advanced/chameleon/black
 	cost = 5
 

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -18,6 +18,14 @@
 	item = /obj/item/card/id/advanced/chameleon
 	cost = 2
 
+/datum/uplink_item/stealthy_tools/agent_card_advanced
+	name = "Advanced Agent Identification Card"
+	desc = "Created by Cybersun Industries to be the ultimate for field operations, this upgraded Agent ID \
+	comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
+	standard Nanotrasen access codes in one conveinent package. Now in glossy olive by default!"
+	item = /obj/item/card/id/advanced/chameleon/black
+	cost = 5
+
 /datum/uplink_item/stealthy_tools/ai_detector
 	name = "Artificial Intelligence Detector"
 	desc = "A functional multitool that turns red when it detects an artificial intelligence watching it, and can be \

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -22,7 +22,7 @@
 	name = "Advanced Agent Identification Card"
 	desc = "Created by Cybersun Industries to be the ultimate for field operations, this upgraded Agent ID \
 			comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
-			standard Nanotrasen access codes in one conveinent package. Now in glossy olive by default!"
+			standard Nanotrasen access codes in one conveinent package. Now in glossy black by default!"
 	item = /obj/item/card/id/advanced/chameleon/black
 	cost = 5
 

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -21,8 +21,8 @@
 /datum/uplink_item/stealthy_tools/agent_card_advanced
 	name = "Advanced Agent Identification Card"
 	desc = "Created by Cybersun Industries to be the ultimate for field operations, this upgraded Agent ID \
-	comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
-	standard Nanotrasen access codes in one conveinent package. Now in glossy black by default!"
+			comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
+			standard Nanotrasen access codes in one conveinent package. Now in glossy olive by default!"
 	item = /obj/item/card/id/advanced/chameleon/black
 	cost = 5
 


### PR DESCRIPTION
## About The Pull Request
Adds the Deluxe Agent Card back into the uplink, it was tied into a bundle before and unusable otherwise.

## Why It's Good For The Game

Something that should have been avilable normally and isnt just completely door stucked into a bundle thats never used.

## Changelog

:cl: Gonenoculer5
add: Re-added the Deluxe Agent Card to the uplink.
/:cl: