### PR TITLE
Adds a lightswitch button to the APC UI

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -263,6 +263,7 @@
 		"coverLocked" = coverlocked,
 		"siliconUser" = user.has_unlimited_silicon_privilege || user.using_power_flow_console(),
 		"malfStatus" = get_malf_status(user),
+		"mainLights" = area.lightswitch,
 		"emergencyLights" = !emergency_lights,
 		"nightshiftLights" = nightshift_lights,
 
@@ -307,9 +308,10 @@
 		. = UI_INTERACTIVE
 
 /obj/machinery/power/apc/ui_act(action, params)
+	var/list/locked_actions = list("main_lights", "toggle_nightshift")
 	. = ..()
 
-	if(. || !can_use(usr, 1) || (locked && !usr.has_unlimited_silicon_privilege && !failure_timer && action != "toggle_nightshift"))
+	if(. || !can_use(usr, 1) || (locked && !usr.has_unlimited_silicon_privilege && !failure_timer && !(action in locked_actions)))
 		return
 	switch(action)
 		if("lock")
@@ -366,6 +368,12 @@
 			failure_timer = 0
 			update_appearance()
 			update()
+		if("main_lights")
+			area.lightswitch = !area.lightswitch
+			area.power_change()
+			for(var/obj/machinery/light_switch/light_switch in area)
+				light_switch.update_appearance()
+				SEND_SIGNAL(light_switch, COMSIG_LIGHT_SWITCH_SET, area.lightswitch)
 		if("emergency_lighting")
 			emergency_lights = !emergency_lights
 			for(var/obj/machinery/light/L in area)

--- a/tgui/packages/tgui/interfaces/Apc.js
+++ b/tgui/packages/tgui/interfaces/Apc.js
@@ -7,8 +7,8 @@ export const Apc = (props, context) => {
   return (
     <Window
       width={450}
-      height={445}>
-      <Window.Content scrollable>
+      height={432}>
+      <Window.Content>
         <ApcContent />
       </Window.Content>
     </Window>
@@ -86,7 +86,17 @@ const ApcContent = (props, context) => {
   return (
     <>
       <InterfaceLockNoticeBox />
-      <Section title="Power Status">
+      <Section
+        title="Power Status"
+        buttons={(
+          <Button
+            icon={data.mainLights ? "lightbulb" : "lightbulb-o"}
+            content="Main Lights"
+            color={data.mainLights ? "green" : "red"}
+            onClick={() => act('main_lights')}
+          />
+        )}
+      >
         <LabeledList>
           <LabeledList.Item
             label="Main Breaker"
@@ -196,8 +206,11 @@ const ApcContent = (props, context) => {
             label="Emergency Lighting"
             buttons={(
               <Button
-                icon="lightbulb-o"
+                icon={data.emergencyLights ? "lightbulb" : "lightbulb-o"}
                 content={data.emergencyLights ? 'Enabled' : 'Disabled'}
+                width={6.6}
+                textAlign="left"
+                selected={data.emergencyLights}
                 disabled={locked}
                 onClick={() => act('emergency_lighting')} />
             )} />
@@ -205,8 +218,11 @@ const ApcContent = (props, context) => {
             label="Night Shift Lighting"
             buttons={(
               <Button
-                icon="lightbulb-o"
+                icon={data.nightshiftLights ? "lightbulb" : "lightbulb-o"}
                 content={data.nightshiftLights ? 'Enabled' : 'Disabled'}
+                width={6.6}
+                textAlign="left"
+                selected={data.nightshiftLights}
                 onClick={() => act('toggle_nightshift')} />
             )} />
         </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 'Main Lights' button to the APC user interface, which acts the same as a regular lightswitch.

![After Unlocked](https://user-images.githubusercontent.com/57483089/170886452-397fb2c7-50ff-4b0b-be49-1adea896786f.png)
This also tweaks the 'Emergency lighting' and 'Night shift lighting' buttons so that they always stay the same size when toggled, and makes the lightbulb icon turn on/off too.
<hr>
Full comparison:
<details>
<summary><b>Before:</b></summary>

**Locked:**
![Before Locked](https://user-images.githubusercontent.com/57483089/170886257-575e7c53-1951-4470-976b-c95fc5428a14.png)
**Unlocked:**
![Before Unlocked](https://user-images.githubusercontent.com/57483089/170886261-7d835cef-aec0-4ca4-93ce-8b01efee5e41.png)
</details>
<details>
<summary><b>After:</b></summary>

**Locked:**
![After Locked](https://user-images.githubusercontent.com/57483089/170886285-b1c6711d-9e36-4fcf-9184-f3ca8d1c7b9c.png)
**Unlocked:**
![After Unlocked](https://user-images.githubusercontent.com/57483089/170886291-79f5e9fb-e7f0-4fc7-859f-f2ff86635646.png)
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because of the 'Aesthetics' port area lights have a 50% chance to be turned off at roundstart. Personally I really like the effect that this makes, but some rooms on the station have the lightswitch hidden in a closet somewhere, and if it ever gets destroyed then there's no way to rebuild it (as far as I know).
This PR guarantees that every area on the station will always have *some* way to turn the lights on or off.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added an area lightswitch button to the APC UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
