### PR TITLE
Fixes a small buildmode runtime

### DIFF
--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -11,7 +11,6 @@
 	to_chat(c, span_notice("Left Mouse Button + alt on turf/obj    = Copy object type"))
 	to_chat(c, span_notice("Left Mouse Button on turf/obj          = Place objects"))
 	to_chat(c, span_notice("Right Mouse Button                     = Delete objects"))
-	to_chat(c, "")
 	to_chat(c, span_notice("Use the button in the upper left corner to"))
 	to_chat(c, span_notice("change the direction of built objects."))
 	to_chat(c, span_notice("***********************************************************"))

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -7,7 +7,6 @@
 	to_chat(c, span_notice("Right Mouse Button       = Deconstruct / Delete / Downgrade"))
 	to_chat(c, span_notice("Left Mouse Button + ctrl = R-Window"))
 	to_chat(c, span_notice("Left Mouse Button + alt  = Airlock"))
-	to_chat(c, "")
 	to_chat(c, span_notice("Use the button in the upper left corner to"))
 	to_chat(c, span_notice("change the direction of built objects."))
 	to_chat(c, span_notice("***********************************************************"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes this:
```
runtime error: Empty or null string in to_chat proc call.
 - proc name: to chat (/proc/to_chat)
 -   source file: to_chat.dm,88
 -   usr: El-Shei (/mob/dead/observer)
 -   src: null
 -   usr.loc: the floor (56,58,2) (/turf/open/floor/iron)
 -   call stack:
 - to chat(SabreML (/client), "", null, "", 0, 1, 1, 0)
 - /datum/buildmode_mode/basic (/datum/buildmode_mode/basic): show help(SabreML (/client))
 - Buildmode Help (/atom/movable/screen/buildmode/help): Click(null, "mapwindow.map", "icon-x=20;icon-y=11;left=1;but...")
 - SabreML (/client): Click(Buildmode Help (/atom/movable/screen/buildmode/help), null, "mapwindow.map", "icon-x=20;icon-y=11;left=1;but...")
```
This was caused by an empty `to_chat()` string in the `show_help()` procs of `/datum/buildmode_mode/basic` and `/datum/buildmode_mode/advanced`.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a runtime error caused by the help text of the 'Basic' and 'Advanced' admin buildmodes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
