### PR TITLE
Emagging the tank compressor now releases the tank instead of on double-press of the button

### DIFF
--- a/code/modules/research/anomaly/anomaly_refinery.dm
+++ b/code/modules/research/anomaly/anomaly_refinery.dm
@@ -42,6 +42,12 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_ATOM_INTERNAL_EXPLOSION, .proc/check_test)
 
+/obj/machinery/research/anomaly_refinery/examine_more(mob/user)
+	. = ..()
+	if (obj_flags & EMAGGED)
+		. += span_notice("A small panel on [p_their()] side is dislaying a notice. Something about firmware?")
+
+
 /obj/machinery/research/anomaly_refinery/assume_air(datum/gas_mixture/giver)
 	return null // Required to make the TTV not vent directly into the air.
 
@@ -116,10 +122,25 @@
 		return FALSE
 	return TRUE
 
+/obj/machinery/research/anomaly_refinery/emag_act(mob/user, obj/item/card/emag/emag_card)
+	. = ..()
+	if (obj_flags & EMAGGED)
+		balloon_alert(user, span_warning("already hacked!"))
+		return
+
+	obj_flags |= EMAGGED
+	playsound(src, 'sound/machines/buzz-sigh.ogg', 50, vary = FALSE)
+	say("ERROR: Unauthorized firmware access.")
+	return TRUE
+
 /**
  * Starts a compression test.
  */
 /obj/machinery/research/anomaly_refinery/proc/start_test()
+	if (active)
+		say("ERROR: Already running a compression test.")
+		return
+
 	if(!istype(inserted_core) || !istype(inserted_bomb))
 		end_test("ERROR: Missing equpment. Items ejected.")
 		return
@@ -131,10 +152,30 @@
 	say("Beginning compression test. Opening transfer valve.")
 	active = TRUE
 	test_status = null
+
+	if (obj_flags & EMAGGED)
+		say("ERROR: An firmware issue was detected while starting a process. Running autopatcher.")
+		playsound(src, 'sound/machines/ding.ogg', 50, vary = TRUE)
+		addtimer(CALLBACK(src, .proc/error_test), 2 SECONDS, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_NO_HASH_WAIT) // Synced with the sound.
+		return
+
 	inserted_bomb.toggle_valve(tank_to_target)
-	tank_to_target = null
 	timeout_timer = addtimer(CALLBACK(src, .proc/timeout_test), COMPRESSION_TEST_TIME, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_NO_HASH_WAIT)
 	return
+
+/**
+ * Ejects a live TTV.
+ * Triggered by attempting to operate an emagged anomaly refinery.
+ */
+/obj/machinery/research/anomaly_refinery/proc/error_test()
+	message_admins("[src] was emagged and ejected a TTV")
+	investigate_log("was emagged and ejected a TTV", INVESTIGATE_RESEARCH)
+	obj_flags &= ~EMAGGED
+
+	say("Issue resolved. Have a nice day!")
+	inserted_bomb.toggle_valve(tank_to_target)
+	eject_bomb(force = TRUE)
+	timeout_timer = addtimer(CALLBACK(src, .proc/timeout_test), COMPRESSION_TEST_TIME, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_NO_HASH_WAIT) // Actually start the test so they can't just put the bomb back in.
 
 /**
  * Ends a compression test.
@@ -144,6 +185,8 @@
  */
 /obj/machinery/research/anomaly_refinery/proc/end_test(message)
 	active = FALSE
+	tank_to_target = null
+	test_status = null
 	if(inserted_core)
 		eject_core()
 	if(inserted_bomb)
@@ -216,8 +259,8 @@
 	reaction_increment += 1
 
 /// We dont allow incomplete valves to go in but do code in checks for incomplete valves. Just in case.
-/obj/machinery/research/anomaly_refinery/proc/eject_bomb(mob/user)
-	if(!inserted_bomb || active)
+/obj/machinery/research/anomaly_refinery/proc/eject_bomb(mob/user, force = FALSE)
+	if(!inserted_bomb || (active && !force))
 		return
 	if(user)
 		user.put_in_hands(inserted_bomb)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port of https://github.com/tgstation/tgstation/pull/66647

Not a salt PR i swear

## Why It's Good For The Game
Bugs are bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Spamming the start compression test button will not make the anomaly refinery eject a live TTV.
add: That's what the emag is for.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
