### PR TITLE
Small Teshari tweaks/fixes part 2

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species_types/teshari.dm
@@ -60,10 +60,13 @@
 /datum/species/teshari/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.dna.features["mcolor"] = TESH_BODY_COLOR
 	human.hair_color = TESH_FEATHER_COLOR
-	human.facial_hair_color = COLOR_WHITE
 
 	var/obj/item/organ/external/teshari_feathers/head_feathers = human.internal_organs_slot[ORGAN_SLOT_EXTERNAL_TESHARI_FEATHERS]
 	head_feathers.set_sprite("Plain")
+	var/obj/item/organ/external/teshari_body_feathers/body_feathers = human.internal_organs_slot[ORGAN_SLOT_EXTERNAL_TESHARI_BODY_FEATHERS]
+	body_feathers.set_sprite("None")
+	var/obj/item/organ/external/teshari_ears/ears = human.internal_organs_slot[ORGAN_SLOT_EXTERNAL_TESHARI_EARS]
+	ears.set_sprite("None")
 	human.update_body(TRUE)
 
 #undef TESH_BODY_COLOR

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -493,8 +493,9 @@
 	var/mutable_appearance/tail_secondary = mutable_appearance(tail_primary.icon, "[tail_primary.icon_state]_secondary", layer = -image_layer)
 	var/mutable_appearance/tail_tertiary = mutable_appearance(tail_primary.icon, "[tail_primary.icon_state]_tertiary", layer = -image_layer)
 
-	tail_secondary.color = owner.dna.features["mcolor2"]
-	tail_tertiary.color = owner.dna.features["mcolor3"]
+	if(owner)
+		tail_secondary.color = owner.dna.features["mcolor2"]
+		tail_tertiary.color = owner.dna.features["mcolor3"]
 
 	overlay_list += tail_secondary
 	overlay_list += tail_tertiary


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a runtime *sometimes* being caused when a Teshari tail is separated from a Teshari. I can't reproduce it but there's no harm in checking for `owner` anyway.

Also makes sure that the Teshari species preview icon always look like this rather than still having some randomised features:
![image](https://user-images.githubusercontent.com/57483089/172840736-0f4922f1-3573-4fbd-9710-58e96ef596b9.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency & runtimes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the species preview image for Teshari not being consistent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
