### PR TITLE
Fixes another random CI failure

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -229,8 +229,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/turf/atom_turf = get_turf(checked_atom) //use checked_atom's turfs, as it's coords are the same as checked_atom's AND checked_atom's coords are lost if it is inside another atom
 	if(!atom_turf)
 		return null
-	var/final_x = atom_turf.x + rough_x
-	var/final_y = atom_turf.y + rough_y
+	var/final_x = clamp(atom_turf.x + rough_x, 1, world.maxx)
+	var/final_y = clamp(atom_turf.y + rough_y, 1, world.maxy)
 
 	if(final_x || final_y)
 		return locate(final_x, final_y, atom_turf.z)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -92,6 +92,7 @@
 #include "emoting.dm"
 #include "food_edibility_check.dm"
 #include "gas_transfer.dm"
+#include "get_turf_pixel.dm"
 #include "greyscale_config.dm"
 #include "heretic_knowledge.dm"
 #include "heretic_rituals.dm"

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -1,0 +1,11 @@
+///ensures that get_turf_pixel() returns turfs within the bounds of the map,
+///even when called on a movable with its sprite out of bounds
+/datum/unit_test/get_turf_pixel
+
+/datum/unit_test/get_turf_pixel/Run()
+	//we need long larry to peek over the top edge of the earth
+	var/turf/north = locate(1, world.maxy, run_loc_floor_bottom_left.z)
+
+	//hes really long, so hes really good at peaking over the edge of the map
+	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
+	TEST_ASSERT(istype(get_turf_pixel(long_larry), /turf), "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/67430.
This fixes a runtime error caused by the Colossus megafauna spawning at the very top of the map, and adds a unit test to prevent the same from happening again in the future.
Because the Colossus is 3 tiles tall its upper half could be outside of the map's boundries, and when it tried to update the lighting glow on the turf underneath it, this would happen:
```
Runtime in lighting_source.dm,244: Cannot read null.x
  proc name: update corners (/datum/light_source/proc/update_corners)
  src: /datum/light_source (/datum/light_source)
  call stack:
  /datum/light_source (/datum/light_source): update corners()
  Lighting (/datum/controller/subsystem/lighting): fire(0, 1)
  Lighting (/datum/controller/subsystem/lighting): Initialize(440451)
  Master (/datum/controller/master): Initialize(10, 0, 1)
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a semi-rare CI failure, see [here](https://github.com/pariahstation/Pariah-Station/runs/6812172699?check_suite_focus=true#step:8:90).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kylerace
fix: Fixed a runtime caused by tall mobs spawning at the top of the map.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
