### PR TITLE
Girder/wall hiddenprints fix

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -162,6 +162,7 @@
 					false_wall.set_wall_information(S.material_type, reinforced_material, wall_paint, stripe_paint)
 					transfer_fingerprints_to(false_wall)
 				qdel(src)
+				return
 
 		add_hiddenprint(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes these runtimes:
```
runtime error: Attempted to add a new component of type [/datum/component/forensics] to a qdeleting parent of type [/obj/structure/girder]!
 - proc name:  AddComponent (/datum/proc/_AddComponent)
 -   source file: _component.dm,405
 -   usr: El-Shei (/mob/living/carbon/human)
 -   src: the girder (/obj/structure/girder)
 -   usr.loc: the floor (89,129,2) (/turf/open/floor/iron)
 -   src.loc: null
 -   call stack:
 - the girder (/obj/structure/girder):  AddComponent(/list (/list))
 - the girder (/obj/structure/girder): add hiddenprint(El-Shei (/mob/living/carbon/human))
 - the girder (/obj/structure/girder): attackby(the iron (/obj/item/stack/sheet/iron), El-Shei (/mob/living/carbon/human), "icon-x=5;icon-y=21;left=1;butt...")
 - the iron (/obj/item/stack/sheet/iron): melee attack chain(El-Shei (/mob/living/carbon/human), the girder (/obj/structure/girder), "icon-x=5;icon-y=21;left=1;butt...")
 - El-Shei (/mob/living/carbon/human): ClickOn(the girder (/obj/structure/girder), "icon-x=5;icon-y=21;left=1;butt...")
 - the girder (/obj/structure/girder): Click(the wall (90,129,2) (/turf/closed/wall), "mapwindow.map", "icon-x=5;icon-y=21;left=1;butt...")
```
```
runtime error: Cannot execute null.add hiddenprint().
 - proc name: add hiddenprint (/atom/proc/add_hiddenprint)
 -   source file: detective_work.dm,64
 -   usr: El-Shei (/mob/living/carbon/human)
 -   src: the girder (/obj/structure/girder)
 -   usr.loc: the floor (89,129,2) (/turf/open/floor/iron)
 -   src.loc: null
 -   call stack:
 - the girder (/obj/structure/girder): add hiddenprint(El-Shei (/mob/living/carbon/human))
 - the girder (/obj/structure/girder): attackby(the iron (/obj/item/stack/sheet/iron), El-Shei (/mob/living/carbon/human), "icon-x=5;icon-y=21;left=1;butt...")
 - the iron (/obj/item/stack/sheet/iron): melee attack chain(El-Shei (/mob/living/carbon/human), the girder (/obj/structure/girder), "icon-x=5;icon-y=21;left=1;butt...")
 - El-Shei (/mob/living/carbon/human): ClickOn(the girder (/obj/structure/girder), "icon-x=5;icon-y=21;left=1;butt...")
 - the girder (/obj/structure/girder): Click(the wall (90,129,2) (/turf/closed/wall), "mapwindow.map", "icon-x=5;icon-y=21;left=1;butt...")
```
These were being caused by `/obj/structure/girder/attackby()` not returning after the girder is replaced with a wall.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
🫕
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a small runtime error from wall building.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
