### PR TITLE
Adds Round Time and Alert Level to Hub entry Port

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -340,6 +340,9 @@ GLOBAL_VAR(restart_counter)
 	if (features)
 		s += ": [jointext(features, ", ")]"
 
+	s += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
+	s += "<br>Alert level: <b>[capitalize(get_security_level())]</b>"
+
 	status = s
 
 /world/proc/update_hub_visibility(new_visibility)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of:
- https://github.com/tgstation/tgstation/pull/67607

Adds station timer and security level information to the server's byond hub entry.
![image](https://user-images.githubusercontent.com/62493359/174740173-5a24d47a-8bd5-48c5-8a2e-b54b41b22f15.png)

## Why It's Good For The Game

To quote from the original PR:

> It's useful being able to see the round time and alert level, it helps players make informed decisions when joining the server

> Another thing is that these are dynamic elements of the hub entry, they'll never always be the same
in tandem with the round time the alert level also makes people intrigued like "round time 0:20 and red alert? shit must be going down" or "round time 2:00 and green alert? they probably have all the cool endgame stuff lets check it out"

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 13spacemen
add: Added round time and alert to the hub
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
