### PR TITLE
Allow toggling holiday floor fuckery

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -221,6 +221,8 @@
 
 /datum/config_entry/flag/allow_holidays
 
+/datum/config_entry/flag/disable_holiday_floor_effects //For when you need consistency or don't enjoy garish vomit.
+
 
 /datum/config_entry/flag/admin_legacy_system //Defines whether the server uses the legacy admin system with admins.txt or the SQL system
 	protection = CONFIG_ENTRY_LOCKED

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -7,7 +7,9 @@
 #define PRIDE_ALPHA 60
 
 /obj/effect/turf_decal/tile/Initialize(mapload)
-	if(SSevents.holidays)
+	if(!mapload) //Player or admin created, Don't touch it regardless.
+		return ..()
+	if(SSevents.holidays && !CONFIG_GET(flag/disable_holiday_floor_effects))
 		if (SSevents.holidays[APRIL_FOOLS])
 			color = "#[random_short_color()]"
 		else if (SSevents.holidays[PRIDE_WEEK])

--- a/config/config.txt
+++ b/config/config.txt
@@ -303,6 +303,9 @@ POPUP_ADMIN_PM
 ## Uncomment to allow special 'Easter-egg' events on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR
 ALLOW_HOLIDAYS
 
+##Uncomment to disable specifically the ability for holidays to alter the color of floor decals. (April Fools and Pride Week)
+#DISABLE_HOLIDAY_FLOOR_EFFECTS
+
 ## Uncomment to show the names of the admin sending a pm from IRC instead of showing as a stealthmin.
 #SHOW_IRC_NAME
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows operators and testers/mappers to prevent holidays from messing with floor colorations

## Why It's Good For The Game

Consistency and the ability for mapping work to continue with the holiday system MOSTLY enabled.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: Holidays can now be prevented from making changes to the floor tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
