### PR TITLE
Updates antagonist Dummy's

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -37,12 +37,12 @@
 	. = ..()
 
 /datum/antagonist/obsessed/get_preview_icon()
-	var/mob/living/carbon/human/dummy/consistent/victim_dummy = new
-	victim_dummy.hair_color = "#bb9966" // Brown
-	victim_dummy.hairstyle = "Messy"
-	victim_dummy.update_hair()
+	var/mob/living/carbon/human/dummy/consistent/obsessed_dummy = new
+	obsessed_dummy.hair_color = "#bb9966" // Brown
+	obsessed_dummy.hairstyle = "Messy"
+	obsessed_dummy.update_hair(TRUE)
 
-	var/icon/obsessed_icon = render_preview_outfit(preview_outfit)
+	var/icon/obsessed_icon = render_preview_outfit(preview_outfit,obsessed_dummy)
 	obsessed_icon.Blend(icon('icons/effects/blood.dmi', "uniformblood"), ICON_OVERLAY)
 
 	var/icon/final_icon = finish_preview_icon(obsessed_icon)
@@ -59,11 +59,11 @@
 /datum/outfit/obsessed
 	name = "Obsessed (Preview only)"
 
-	uniform = /obj/item/clothing/under/misc/overalls
+	uniform = /obj/item/clothing/under/rank/medical/doctor
 	gloves = /obj/item/clothing/gloves/color/latex
 	mask = /obj/item/clothing/mask/surgical
-	neck = /obj/item/camera
-	suit = /obj/item/clothing/suit/apron
+	l_hand = /obj/item/camera
+	suit = /obj/item/clothing/suit/apron/surgical
 
 /datum/outfit/obsessed/post_equip(mob/living/carbon/human/H)
 	for(var/obj/item/carried_item in H.get_equipped_items(TRUE))

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -42,7 +42,7 @@
 	obsessed_dummy.hairstyle = "Messy"
 	obsessed_dummy.update_hair(TRUE)
 
-	var/icon/obsessed_icon = render_preview_outfit(preview_outfit,obsessed_dummy)
+	var/icon/obsessed_icon = render_preview_outfit(preview_outfit, obsessed_dummy)
 	obsessed_icon.Blend(icon('icons/effects/blood.dmi', "uniformblood"), ICON_OVERLAY)
 
 	var/icon/final_icon = finish_preview_icon(obsessed_icon)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -206,7 +206,7 @@
 /datum/antagonist/rev/head/proc/make_assistant_icon(hairstyle)
 	var/mob/living/carbon/human/dummy/consistent/assistant = new
 	assistant.hairstyle = hairstyle
-	assistant.update_hair()
+	assistant.update_hair(TRUE)
 
 	var/icon/assistant_icon = render_preview_outfit(/datum/outfit/job/assistant/consistent, assistant)
 	assistant_icon.ChangeOpacity(0.5)
@@ -434,7 +434,7 @@
 	if (. == STATION_VICTORY)
 		// If the revolution was quelled, make rev heads unable to be revived through pods
 		for (var/datum/mind/rev_head as anything in ex_headrevs)
-			if(!isnull(rev_head.current))	
+			if(!isnull(rev_head.current))
 				ADD_TRAIT(rev_head.current, TRAIT_DEFIB_BLACKLISTED, REF(src))
 				rev_head.current.med_hud_set_status()
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -353,11 +353,11 @@
 
 /datum/antagonist/traitor/get_preview_icon()
 	var/mob/living/carbon/human/dummy/consistent/traitor_dummy = new
-	traitor_dummy.hair_color = "#dba86e53"
-	traitor_dummy.hairstyle = "CIA"
+	traitor_dummy.hair_color = "#4D4D4D"
+	traitor_dummy.hairstyle = "Business Hair"
 	traitor_dummy.update_hair(TRUE)
 
-	var/icon/traitor_icon = render_preview_outfit(preview_outfit,traitor_dummy)
+	var/icon/traitor_icon = render_preview_outfit(preview_outfit, traitor_dummy)
 
 	var/icon/final_icon = finish_preview_icon(traitor_icon)
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -336,10 +336,10 @@
 /datum/outfit/traitor
 	name = "Traitor (Preview only)"
 
-	uniform = /obj/item/clothing/under/color/grey
-	suit = /obj/item/clothing/suit/hooded/ablative
+	uniform = /obj/item/clothing/under/color/grey/ancient
 	gloves = /obj/item/clothing/gloves/color/yellow
 	mask = /obj/item/clothing/mask/gas
+	shoes = /obj/item/clothing/shoes/jackboots
 	l_hand = /obj/item/melee/energy/sword
 	r_hand = /obj/item/gun/energy/recharge/ebow
 
@@ -349,3 +349,16 @@
 	sword.worn_icon_state = "e_sword_on_red"
 
 	H.update_inv_hands()
+
+
+/datum/antagonist/traitor/get_preview_icon()
+	var/mob/living/carbon/human/dummy/consistent/traitor_dummy = new
+	traitor_dummy.hair_color = "#dba86e53"
+	traitor_dummy.hairstyle = "CIA"
+	traitor_dummy.update_hair(TRUE)
+
+	var/icon/traitor_icon = render_preview_outfit(preview_outfit,traitor_dummy)
+
+	var/icon/final_icon = finish_preview_icon(traitor_icon)
+
+	return final_icon


### PR DESCRIPTION
Updates the antagonist datums to have actual nice looking dummies.

## About The Pull Request

Antag preview icons didn't have update_hair() set to TRUE, making none of the hair changes show. This has been remidied.

## Changelog

:cl: Gonenoculer5
fix: We've given the antags a good spray of Barbers Aid, so they all have proper hair now. Someone should shoot the person that gave them all baldium.
/:cl: