### PR TITLE
Host sanctioned emote spamming, or, audible *scream emote

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -57,9 +57,9 @@
 	var/mob/living/carbon/human/human = user
 	if(human.dna.species?.scream_verb)
 		if(human.mind?.miming)
-			return "[human.dna.species?.scream_verb] silently!"
+			return "[human.dna.species.scream_verb] silently!"
 		else
-			return "[human.dna.species?.scream_verb]!"
+			return "[human.dna.species.scream_verb]!"
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)
 	if(!ishuman(user))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -52,6 +52,15 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 
+/datum/emote/living/carbon/human/scream/select_message_type(mob/user, msg, intentional)
+	. = ..()
+	var/mob/living/carbon/human/human = user
+	if(human.dna.species?.scream_verb)
+		if(human.mind?.miming)
+			return "[human.dna.species?.scream_verb] silently!"
+		else
+			return "[human.dna.species?.scream_verb]!"
+
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)
 	if(!ishuman(user))
 		return

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -50,7 +50,6 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
-	only_forced_audio = TRUE
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -55,7 +55,7 @@
 /datum/emote/living/carbon/human/scream/select_message_type(mob/user, msg, intentional)
 	. = ..()
 	var/mob/living/carbon/human/human = user
-	if(human.dna.species?.scream_verb)
+	if(human.dna.species.scream_verb)
 		if(human.mind?.miming)
 			return "[human.dna.species.scream_verb] silently!"
 		else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -67,6 +67,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/nojumpsuit = FALSE
 	///Affects the speech message, for example: Motharula flutters, "My speech message is flutters!"
 	var/say_mod = "says"
+	///Affects the speecies' screams, for example: Motharula buzzes!"
+	var/scream_verb = "screams"
 	///What languages this species can understand and say. Use a [language holder datum][/datum/language_holder] in this var.
 	var/species_language_holder = /datum/language_holder
 	/**

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/nojumpsuit = FALSE
 	///Affects the speech message, for example: Motharula flutters, "My speech message is flutters!"
 	var/say_mod = "says"
-	///Affects the speecies' screams, for example: Motharula buzzes!"
+	///Affects the species' screams, for example: Motharula buzzes!"
 	var/scream_verb = "screams"
 	///What languages this species can understand and say. Use a [language holder datum][/datum/language_holder] in this var.
 	var/species_language_holder = /datum/language_holder

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/nojumpsuit = FALSE
 	///Affects the speech message, for example: Motharula flutters, "My speech message is flutters!"
 	var/say_mod = "says"
-	///Affects the species' screams, for example: Motharula buzzes!"
+	///Affects the species' screams, for example: "Motharula buzzes!"
 	var/scream_verb = "screams"
 	///What languages this species can understand and say. Use a [language holder datum][/datum/language_holder] in this var.
 	var/species_language_holder = /datum/language_holder

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -2,6 +2,7 @@
 	name = "\improper Monkey"
 	id = SPECIES_MONKEY
 	say_mod = "chimpers"
+	scream_verb = "screeches"
 	bodytype = BODYTYPE_ORGANIC | BODYTYPE_MONKEY
 	attack_verb = "bite"
 	attack_effect = ATTACK_EFFECT_BITE

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -3,6 +3,7 @@
 	plural_form = "Gamuioda"
 	id = SPECIES_MOTH
 	say_mod = "flutters"
+	scream_verb = "buzzes"
 	default_color = "00FF00"
 	species_traits = list(MUTCOLORS, LIPS, HAS_FLESH, HAS_BONE, HAS_MARKINGS, TRAIT_ANTENNAE, BODY_RESIZABLE)
 	inherent_traits = list(

--- a/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -3,6 +3,7 @@
 	name = "Vox"
 	id = SPECIES_VOX
 	say_mod = "skrees"
+	scream_verb = "shrieks"
 	default_color = "#1e5404"
 	species_eye_path = 'icons/mob/species/vox/eyes.dmi'
 	species_traits = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now hear the species specific scream sound when using *scream, not just when its forced.
Also species specific scream messages, _buzzes!_ and _shrieks!_ instead of _screams!_ wherever appropriate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The scream emote is now audible.
add: Species specific scream messages, so something like "Vox shrieks!", "Monkey screeches!" and "Moth buzzes!".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
