### PR TITLE
3/4ifies centcom and some indestructible walls

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
@@ -4,7 +4,7 @@
 /area/icemoon/surface/outdoors/unexplored)
 "b" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/icemoon/surface/outdoors)
 "c" = (
 /turf/open/floor/mineral/diamond,

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
@@ -14,7 +14,7 @@
 /area/ruin/powered/mailroom)
 "aG" = (
 /obj/structure/sign/warning/coldtemp,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "ba" = (
 /obj/structure/window/reinforced{
@@ -139,7 +139,7 @@
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/unexplored)
 "ms" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "mA" = (
 /obj/structure/fence/corner,
@@ -214,7 +214,7 @@
 /area/ruin/powered/mailroom)
 "vU" = (
 /obj/structure/sign/departments/cargo,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "vV" = (
 /obj/effect/decal/cleanable/oil,
@@ -257,7 +257,7 @@
 /area/ruin/powered/mailroom)
 "AX" = (
 /obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "BZ" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
@@ -270,7 +270,7 @@
 /area/ruin/powered/mailroom)
 "CW" = (
 /obj/structure/sign/poster/official/obey,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "DR" = (
 /obj/structure/fence/post{
@@ -297,7 +297,7 @@
 /area/ruin/powered/mailroom)
 "Gn" = (
 /obj/structure/sign/poster/ripped,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "HH" = (
 /turf/open/floor/iron/smooth_corner{
@@ -512,7 +512,7 @@
 /area/ruin/powered/mailroom)
 "Xa" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "XO" = (
 /turf/open/floor/iron/smooth_corner{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -58,7 +58,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ak" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/ruin/unpowered/ash_walkers)
 "al" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -502,7 +502,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bG" = (
-/turf/closed/indestructible/riveted/boss/see_through,
+/turf/closed/wall/indestructible/reinforced/boss/see_through,
 /area/ruin/unpowered/ash_walkers)
 "bH" = (
 /obj/structure/necropolis_gate,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
@@ -10,7 +10,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "d" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/lavaland/surface/outdoors)
 "e" = (
 /obj/machinery/wish_granter,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -185,7 +185,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "nT" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/ruin/powered/gluttony)
 "pj" = (
 /obj/structure/stone_tile/block/burnt{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hierophant.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hierophant.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted/hierophant,
+/turf/closed/indestructible/hierophant,
 /area/ruin/unpowered/hierophant)
 "b" = (
 /turf/open/indestructible/hierophant,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -155,7 +155,7 @@
 /turf/open/lava/smooth,
 /area/ruin/powered/pride)
 "Y" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/ruin/powered/pride)
 "Z" = (
 /obj/structure/stone_tile/block{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/unpowered)
 "b" = (
 /turf/open/lava/smooth/lava_land_surface,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wizard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wizard.dmm
@@ -269,7 +269,7 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "D" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/lavaland/surface/outdoors)
 "E" = (
 /obj/structure/stone_tile/block{
@@ -286,7 +286,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "G" = (
-/turf/closed/indestructible/riveted/boss/see_through,
+/turf/closed/wall/indestructible/reinforced/boss/see_through,
 /area/lavaland/surface/outdoors)
 "H" = (
 /obj/structure/necropolis_gate,

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -335,7 +335,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bW" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	color = "#FF8888"
 	},
 /area/ruin/space/derelict/bridge/ai_upload)

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -287,7 +287,7 @@
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
 "aZ" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "ba" = (
 /turf/closed/mineral/random,

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -46,7 +46,7 @@
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/hellfactory)
 "ah" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "ai" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -58,7 +58,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer4{
 	dir = 8
 	},
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{

--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -1238,7 +1238,7 @@
 /turf/closed/mineral/asteroid/porous,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Bo" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "BF" = (
 /obj/machinery/door/window/survival_pod{
@@ -1260,7 +1260,7 @@
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "BJ" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility/secretroom)
 "BL" = (
 /obj/structure/table/wood,
@@ -1360,7 +1360,7 @@
 /obj/structure/light_puzzle{
 	puzzle_id = "hilbert"
 	},
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Eu" = (
 /obj/item/kirbyplants/random,
@@ -1558,7 +1558,7 @@
 /turf/open/floor/grass/fairy,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Iy" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility/secretroom)
 "ID" = (
 /obj/structure/table/reinforced/rglass,
@@ -1878,7 +1878,7 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Ok" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "OA" = (
 /obj/machinery/door/airlock/titanium,
@@ -1983,7 +1983,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Rq" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/unpowered/no_grav)
 "Ru" = (
 /obj/effect/turf_decal/stripes/red/line{

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -717,11 +717,11 @@
 /turf/open/floor/iron/white,
 /area/awaymission/cabin)
 "cx" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/cabin/caves/mountain)
 "cy" = (
 /obj/structure/sign/poster/contraband/fun_police,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/cabin/caves/mountain)
 "cz" = (
 /obj/machinery/light/directional/north,
@@ -2415,7 +2415,7 @@
 /turf/open/floor/plating/snowed/snow_cabin,
 /area/awaymission/cabin/snowforest/sovietsurface)
 "ii" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "ij" = (
 /obj/structure/table/wood,
@@ -3604,11 +3604,11 @@
 /area/awaymission/cabin/snowforest/sovietsurface)
 "nn" = (
 /obj/structure/sign/warning/explosives,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "no" = (
 /obj/structure/sign/warning,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "np" = (
 /turf/closed/indestructible/fakedoor{

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3,7 +3,7 @@
 /turf/open/space,
 /area/space)
 "ab" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/undergroundoutpost45/caves)
 "ac" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/CTF/classic.dmm
+++ b/_maps/map_files/CTF/classic.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "av" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/ctf)
 "aY" = (
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/map_files/CTF/cruiser.dmm
+++ b/_maps/map_files/CTF/cruiser.dmm
@@ -32,7 +32,7 @@
 /turf/open/floor/pod/light,
 /area/ctf)
 "ck" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/ctf)
 "cl" = (
 /obj/structure/window/reinforced{
@@ -42,7 +42,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/ctf)
 "cu" = (
 /obj/machinery/capture_the_flag/green,
@@ -152,7 +152,7 @@
 /turf/closed/indestructible/alien,
 /area/ctf)
 "fU" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ctf)
 "gr" = (
 /obj/effect/turf_decal/siding/purple{
@@ -220,7 +220,7 @@
 	resistance_flags = 64
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/ctf)
 "lL" = (
 /obj/structure/table/reinforced/ctf,
@@ -237,7 +237,7 @@
 /obj/structure/sign/warning/radiation/rad_area{
 	resistance_flags = 64
 	},
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ctf)
 "lY" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
@@ -547,7 +547,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 4
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/ctf)
 "FZ" = (
 /obj/effect/turf_decal/tile/red{

--- a/_maps/map_files/CTF/fourSide.dmm
+++ b/_maps/map_files/CTF/fourSide.dmm
@@ -68,7 +68,7 @@
 /turf/open/floor/iron/dark,
 /area/ctf)
 "cJ" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/ctf)
 "df" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -198,7 +198,7 @@
 /turf/open/floor/iron/dark,
 /area/ctf)
 "lt" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/template_noop)
 "lF" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,

--- a/_maps/map_files/CTF/limbo.dmm
+++ b/_maps/map_files/CTF/limbo.dmm
@@ -1044,7 +1044,7 @@
 /turf/open/floor/carpet/orange,
 /area/ctf)
 "Xl" = (
-/turf/closed/wall/indestructible/reinforced/uranium,
+/turf/closed/wall/indestructible/uranium,
 /area/ctf)
 "XC" = (
 /obj/structure/barricade/security/ctf,

--- a/_maps/map_files/CTF/limbo.dmm
+++ b/_maps/map_files/CTF/limbo.dmm
@@ -1044,7 +1044,7 @@
 /turf/open/floor/carpet/orange,
 /area/ctf)
 "Xl" = (
-/turf/closed/indestructible/riveted/uranium,
+/turf/closed/wall/indestructible/reinforced/uranium,
 /area/ctf)
 "XC" = (
 /obj/structure/barricade/security/ctf,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4917,7 +4917,7 @@
 /turf/open/floor/iron,
 /area/cargo/lobby)
 "bLq" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/map_files/Mafia/mafia_ayylmao.dmm
+++ b/_maps/map_files/Mafia/mafia_ayylmao.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "b" = (
 /turf/closed/indestructible/alien,

--- a/_maps/map_files/Mafia/mafia_ball.dmm
+++ b/_maps/map_files/Mafia/mafia_ball.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "b" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/mafia)
 "c" = (
 /turf/closed/wall/rust,

--- a/_maps/map_files/Mafia/mafia_gothic.dmm
+++ b/_maps/map_files/Mafia/mafia_gothic.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "b" = (
 /turf/closed/wall/mineral/iron,

--- a/_maps/map_files/Mafia/mafia_lavaland.dmm
+++ b/_maps/map_files/Mafia/mafia_lavaland.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "c" = (
 /turf/closed/wall/rust,
@@ -350,7 +350,7 @@
 /turf/open/floor/iron/dark,
 /area/mafia)
 "Y" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 
 (1,1,1) = {"

--- a/_maps/map_files/Mafia/mafia_snow.dmm
+++ b/_maps/map_files/Mafia/mafia_snow.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "b" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/mafia)
 "d" = (
 /turf/open/floor/plating,

--- a/_maps/map_files/Mafia/mafia_spiderclan.dmm
+++ b/_maps/map_files/Mafia/mafia_spiderclan.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "b" = (
 /obj/structure/closet/cabinet{

--- a/_maps/map_files/Mafia/mafia_syndie.dmm
+++ b/_maps/map_files/Mafia/mafia_syndie.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/mafia)
 "b" = (
 /obj/structure/closet/syndicate{
@@ -129,7 +129,7 @@
 	},
 /area/mafia)
 "w" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/mafia)
 "x" = (
 /obj/effect/turf_decal/tile/red,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9720,7 +9720,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cDz" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/lavaland/surface/outdoors)
 "ac" = (
 /obj/structure/stone_tile/block{
@@ -1307,7 +1307,7 @@
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
 "fV" = (
-/turf/closed/indestructible/riveted/boss/see_through,
+/turf/closed/wall/indestructible/reinforced/boss/see_through,
 /area/lavaland/surface/outdoors)
 "fW" = (
 /obj/structure/necropolis_gate/locked,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30150,7 +30150,7 @@
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "BOMB RANGE"
 	},
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},
@@ -30903,7 +30903,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cnq" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -248,7 +248,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_bombthreat)
 "aR" = (
 /obj/item/kirbyplants{
@@ -293,7 +293,7 @@
 /area/centcom/briefing)
 "aW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_bioterrorism)
 "aZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -561,7 +561,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/courtroom)
 "bK" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_fridgerummage)
 "bL" = (
 /obj/structure/chair/stool/bar/directional/west,
@@ -602,7 +602,7 @@
 /area/centcom/courtroom)
 "bR" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/admin/storage)
 "bS" = (
 /obj/structure/closet{
@@ -707,7 +707,7 @@
 /area/tdome/observation)
 "ce" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/armory)
 "cf" = (
 /obj/effect/turf_decal/siding/wood{
@@ -716,7 +716,7 @@
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
 "cg" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/evacuation)
 "ch" = (
 /obj/machinery/firealarm/directional/east,
@@ -1964,7 +1964,7 @@
 /area/centcom/fore)
 "fC" = (
 /obj/structure/sign/warning/nosmoking,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/tdome/observation)
 "fD" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2361,7 +2361,7 @@
 /turf/open/floor/wood/tile,
 /area/syndicate_mothership/control)
 "gO" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/briefing)
 "gQ" = (
 /obj/structure/rack,
@@ -2900,7 +2900,7 @@
 	},
 /area/awaymission/errorroom)
 "il" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/prison)
 "im" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2911,10 +2911,10 @@
 /area/centcom/prison)
 "in" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/control)
 "io" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/control)
 "ip" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3047,7 +3047,7 @@
 /turf/open/floor/iron,
 /area/centcom/prison)
 "iF" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/supply)
 "iG" = (
 /turf/closed/indestructible/fakedoor{
@@ -3056,11 +3056,11 @@
 /area/centcom/supply)
 "iH" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/prison)
 "iI" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/prison/cells)
 "iJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3090,7 +3090,7 @@
 /area/centcom/prison)
 "iN" = (
 /obj/machinery/status_display/supply,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/supply)
 "iO" = (
 /obj/effect/turf_decal/delivery,
@@ -3697,7 +3697,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership)
 "kv" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_bombthreat)
 "kw" = (
 /turf/open/floor/iron/showroomfloor,
@@ -4410,7 +4410,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
 "mD" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ferry)
 "mE" = (
 /obj/structure/chair/comfy/brown{
@@ -4663,7 +4663,7 @@
 	},
 /area/abductor_ship)
 "ng" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "ni" = (
 /obj/machinery/light/directional/south,
@@ -4805,7 +4805,7 @@
 /turf/open/floor/iron,
 /area/centcom/supply)
 "nH" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_chemicalwarfare)
 "nJ" = (
 /obj/machinery/firealarm/directional/south,
@@ -5351,7 +5351,7 @@
 /area/syndicate_mothership/control)
 "pc" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/courtroom)
 "pd" = (
 /obj/item/clipboard,
@@ -5916,7 +5916,7 @@
 /turf/open/floor/grass,
 /area/centcom/evacuation)
 "qE" = (
-/turf/closed/indestructible/riveted/uranium,
+/turf/closed/wall/indestructible/reinforced/uranium,
 /area/wizard_station)
 "qF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5961,7 +5961,7 @@
 /area/syndicate_mothership/control)
 "qR" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ferry)
 "qS" = (
 /obj/machinery/door/airlock/centcom{
@@ -6131,7 +6131,7 @@
 /area/centcom/admin)
 "rz" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ferry)
 "rB" = (
 /obj/structure/table/reinforced,
@@ -6605,7 +6605,7 @@
 /area/centcom/holding)
 "td" = (
 /obj/structure/sign/departments/drop,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ferry)
 "tg" = (
 /obj/structure/chair{
@@ -6839,7 +6839,7 @@
 /area/centcom/control)
 "tP" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/control)
 "tR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6883,14 +6883,14 @@
 /area/wizard_station)
 "tY" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "uc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
 "uf" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/tdome/administration)
 "ug" = (
 /obj/machinery/light/directional/east,
@@ -8077,7 +8077,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "xN" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -8641,7 +8641,7 @@
 /area/syndicate_mothership/control)
 "zw" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/tdome/observation)
 "zz" = (
 /obj/structure/table/reinforced,
@@ -9005,7 +9005,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "As" = (
 /obj/machinery/computer/communications{
@@ -9186,7 +9186,7 @@
 /area/syndicate_mothership/control)
 "AT" = (
 /obj/structure/sign/departments/medbay/alt,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/control)
 "AU" = (
 /obj/machinery/computer/operating{
@@ -9933,7 +9933,7 @@
 /turf/open/floor/iron,
 /area/centcom/control)
 "CN" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_bioterrorism)
 "CP" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -10041,11 +10041,11 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/syndicate_mothership/control)
 "Di" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/ai_multicam_room)
 "Dj" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/prison/cells)
 "Dk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10303,7 +10303,7 @@
 /area/wizard_station)
 "DT" = (
 /obj/structure/sign/poster/contraband/cc64k_ad,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "DV" = (
 /obj/item/kirbyplants{
@@ -10699,7 +10699,7 @@
 /area/tdome/administration)
 "Fd" = (
 /obj/structure/sign/poster/contraband/free_key,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "Fe" = (
 /obj/structure/sink{
@@ -11266,7 +11266,7 @@
 /area/syndicate_mothership/control)
 "GI" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_bioterrorism)
 "GJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11279,7 +11279,7 @@
 /area/centcom/evacuation)
 "GK" = (
 /obj/structure/cable,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "GN" = (
 /obj/structure/table/reinforced,
@@ -11474,7 +11474,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/syndicate_mothership/control)
 "Hv" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/courtroom)
 "Hy" = (
 /obj/machinery/recharge_station,
@@ -12026,7 +12026,7 @@
 /turf/open/floor/iron,
 /area/tdome/arena)
 "Jb" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/prison/cells)
 "Jc" = (
 /obj/effect/landmark/thunderdome/one,
@@ -12874,7 +12874,7 @@
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
 "LV" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/errorroom)
 "LW" = (
 /turf/closed/mineral/ash_rock,
@@ -13224,7 +13224,7 @@
 /area/centcom/holding)
 "MY" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/briefing)
 "MZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -13674,7 +13674,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/briefing)
 "On" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/admin)
 "Op" = (
 /obj/structure/table/reinforced,
@@ -14203,7 +14203,7 @@
 /area/centcom/armory)
 "PF" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/admin)
 "PH" = (
 /obj/machinery/firealarm/directional/south,
@@ -14530,7 +14530,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/syndicate_mothership/control)
 "QC" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/tdome/observation)
 "QD" = (
 /obj/structure/closet,
@@ -15201,7 +15201,7 @@
 /area/centcom/admin)
 "Sx" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/admin/storage)
 "Sy" = (
 /obj/machinery/light/small/directional/north,
@@ -15815,7 +15815,7 @@
 /area/syndicate_mothership/expansion_bioterrorism)
 "Ue" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_chemicalwarfare)
 "Uf" = (
 /obj/structure/table/reinforced,
@@ -15978,7 +15978,7 @@
 /turf/open/floor/wood/tile,
 /area/syndicate_mothership/control)
 "Uu" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership)
 "Uv" = (
 /obj/structure/table/reinforced,
@@ -16377,7 +16377,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/supply)
 "Vx" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/fore)
 "Vy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16772,7 +16772,7 @@
 /area/centcom/holding)
 "Wx" = (
 /obj/machinery/vending/boozeomat,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/control)
 "Wy" = (
 /obj/structure/chair/office,
@@ -17378,7 +17378,7 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/admin)
 "Ya" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/armory)
 "Yc" = (
 /obj/structure/fireplace,
@@ -17416,7 +17416,7 @@
 /area/syndicate_mothership/control)
 "Yg" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/syndicate_mothership/expansion_bombthreat)
 "Yj" = (
 /obj/structure/chair/comfy/black,
@@ -17454,7 +17454,7 @@
 /turf/open/misc/asteroid,
 /area/centcom/control)
 "Yn" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/supplypod)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -17574,7 +17574,7 @@
 /area/syndicate_mothership)
 "YI" = (
 /obj/structure/sign/warning/nosmoking,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/admin)
 "YJ" = (
 /obj/effect/turf_decal/tile/bar,
@@ -17664,7 +17664,7 @@
 /turf/open/floor/iron/grimy,
 /area/tdome/observation)
 "YU" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/admin/storage)
 "YV" = (
 /obj/structure/closet/lawcloset,
@@ -17708,7 +17708,7 @@
 /area/centcom/evacuation/ship)
 "Za" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/fore)
 "Zb" = (
 /obj/machinery/door/poddoor/shuttledock{

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5916,7 +5916,7 @@
 /turf/open/floor/grass,
 /area/centcom/evacuation)
 "qE" = (
-/turf/closed/wall/indestructible/reinforced/uranium,
+/turf/closed/wall/indestructible/uranium,
 /area/wizard_station)
 "qF" = (
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -46130,7 +46130,7 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "pgA" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -44,7 +44,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ag" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/shuttle/escape/luxury)
 "ah" = (
 /obj/effect/turf_decal/delivery,
@@ -116,7 +116,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "ay" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/shuttle/escape/luxury)
 "az" = (
 /obj/machinery/computer/communications{

--- a/_maps/templates/admin_thunderdome.dmm
+++ b/_maps/templates/admin_thunderdome.dmm
@@ -139,7 +139,7 @@
 /turf/open/floor/iron,
 /area/template_noop)
 "v" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/template_noop)
 "w" = (
 /obj/structure/rack,

--- a/_maps/templates/heretic_sacrifice_template.dmm
+++ b/_maps/templates/heretic_sacrifice_template.dmm
@@ -344,7 +344,7 @@
 /turf/open/misc/ironsand,
 /area/heretic_sacrifice/rust)
 "Fd" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/space)
 "Gl" = (
 /obj/structure/stone_tile/block/burnt{
@@ -446,7 +446,7 @@
 	},
 /area/heretic_sacrifice/ash)
 "La" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/heretic_sacrifice/void)
 "LA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -628,7 +628,7 @@
 /turf/open/indestructible/necropolis/air,
 /area/heretic_sacrifice/flesh)
 "ZA" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/heretic_sacrifice/ash)
 
 (1,1,1) = {"

--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -96,7 +96,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 #define SMOOTH_GROUP_SURVIVAL_TITANIUM_WALLS S_TURF(53) ///turf/closed/wall/mineral/titanium/survival
 #define SMOOTH_GROUP_HOTEL_WALLS S_TURF(54) ///turf/closed/indestructible/hotelwall
 #define SMOOTH_GROUP_MINERAL_WALLS S_TURF(55) ///turf/closed/mineral, /turf/closed/indestructible
-#define SMOOTH_GROUP_BOSS_WALLS S_TURF(56) ///turf/closed/indestructible/riveted/boss
+#define SMOOTH_GROUP_BOSS_WALLS S_TURF(56) ///turf/closed/wall/indestructible/reinforced/boss
 
 #define MAX_S_TURF SMOOTH_GROUP_BOSS_WALLS //Always match this value with the one above it.
 

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -97,8 +97,8 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 /datum/material/uranium
 	name = "uranium"
 	desc = "Uranium"
-	color = rgb(48, 237, 26)
-	greyscale_colors = rgb(48, 237, 26)
+	color = rgb(0, 122, 0)
+	greyscale_colors = rgb(0, 122, 0)
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	value_per_unit = 0.05
@@ -106,6 +106,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	armor_modifiers = list(MELEE = 1.5, BULLET = 1.4, LASER = 0.5, ENERGY = 0.5, BOMB = 0, BIO = 0, FIRE = 1, ACID = 1)
 	wall_type = /turf/closed/wall/mineral/uranium
 	false_wall_type = /obj/structure/falsewall/uranium
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 
 /datum/material/uranium/on_applied(atom/source, amount, material_flags)
 	. = ..()

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -49,6 +49,127 @@
 	baseturfs = /turf/closed/indestructible/sandstone
 	smoothing_flags = SMOOTH_BITMASK
 
+/turf/closed/indestructible/alien
+	name = "alien wall"
+	desc = "A wall with alien alloy plating."
+	icon = 'icons/turf/walls/legacy/abductor_wall.dmi'
+	icon_state = "abductor_wall-0"
+	base_icon_state = "abductor_wall"
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+
+/turf/closed/indestructible/cult
+	name = "runed metal wall"
+	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound. Effectively impervious to conventional methods of destruction."
+	icon = 'icons/turf/walls/legacy/cult_wall.dmi'
+	icon_state = "cult_wall-0"
+	base_icon_state = "cult_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+
+/turf/closed/indestructible/fakedoor
+	name = "CentCom Access"
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
+	icon_state = "fake_door"
+
+/turf/closed/indestructible/rock
+	name = "dense rock"
+	desc = "An extremely densely-packed rock, most mining tools or explosives would never get through this."
+	icon = 'icons/turf/mining.dmi'
+	icon_state = "rock"
+
+/turf/closed/indestructible/rock/snow
+	name = "mountainside"
+	desc = "An extremely densely-packed rock, sheeted over with centuries worth of ice and snow."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "snowrock"
+	bullet_sizzle = TRUE
+	bullet_bounce_sound = null
+
+/turf/closed/indestructible/rock/snow/ice
+	name = "iced rock"
+	desc = "Extremely densely-packed sheets of ice and rock, forged over the years of the harsh cold."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "icerock"
+
+/turf/closed/indestructible/rock/snow/ice/ore
+	icon = 'icons/turf/walls/legacy/icerock_wall.dmi'
+	icon_state = "icerock_wall-0"
+	base_icon_state = "icerock_wall"
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
+	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
+	pixel_x = -4
+	pixel_y = -4
+
+/turf/closed/indestructible/wood
+	icon = 'icons/turf/walls/legacy/wood_wall.dmi'
+	icon_state = "wood_wall-0"
+	base_icon_state = "wood_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+
+/turf/closed/indestructible/paper
+	name = "thick paper wall"
+	desc = "A wall layered with impenetrable sheets of paper."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "paperwall"
+
+/turf/closed/indestructible/necropolis
+	name = "necropolis wall"
+	desc = "A seemingly impenetrable wall."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "necro"
+	explosion_block = 50
+	baseturfs = /turf/closed/indestructible/necropolis
+
+/turf/closed/indestructible/necropolis/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "necro1"
+	return TRUE
+
+/turf/closed/indestructible/iron
+	name = "impervious iron wall"
+	desc = "A wall with tough iron plating."
+	icon = 'icons/turf/walls/legacy/iron_wall.dmi'
+	icon_state = "iron_wall-0"
+	base_icon_state = "iron_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+	opacity = FALSE
+
+/turf/closed/indestructible/boss
+	name = "necropolis wall"
+	desc = "A thick, seemingly indestructible stone wall."
+	icon = 'icons/turf/walls/legacy/boss_wall.dmi'
+	icon_state = "boss_wall-0"
+	base_icon_state = "boss_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_BOSS_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_BOSS_WALLS)
+	explosion_block = 50
+	baseturfs = /turf/closed/wall/indestructible/reinforced/boss
+
+/turf/closed/wall/indestructible/reinforced/boss/see_through
+	opacity = FALSE
+
+/turf/closed/wall/indestructible/reinforced/boss/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "basalt"
+	return TRUE
+
+/turf/closed/indestructible/hierophant
+	name = "wall"
+	desc = "A wall made out of a strange metal. The squares on it pulse in a predictable pattern."
+	icon = 'icons/turf/walls/legacy/hierophant_wall.dmi'
+	icon_state = "wall"
+	smoothing_flags = SMOOTH_CORNERS
+	smoothing_groups = list(SMOOTH_GROUP_HIERO_WALL)
+	canSmoothWith = list(SMOOTH_GROUP_HIERO_WALL)
+
+
 /turf/closed/indestructible/oldshuttle/corner
 	icon_state = "corner"
 
@@ -92,75 +213,66 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	desc = null
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-/turf/closed/indestructible/reinforced
+
+//Walls that will be greyscaled
+/turf/closed/wall/indestructible
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/legacy/reinforced_wall.dmi'
-	icon_state = "reinforced_wall-0"
-	base_icon_state = "reinforced_wall"
+	explosion_block = 50
+
+/turf/closed/indestructible/rust_heretic_act()
+	return
+
+/turf/closed/indestructible/TerraformTurf(path, new_baseturf, flags, defer_change = FALSE, ignore_air = FALSE)
+	return
+
+/turf/closed/indestructible/acid_act(acidpwr, acid_volume, acid_id)
+	return FALSE
+
+/turf/closed/indestructible/Melt()
+	to_be_destroyed = FALSE
+	return src
+
+/turf/closed/indestructible/singularity_act()
+	return
+
+/turf/closed/wall/indestructible/reinforced
+	name = "reinforced wall"
+	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
+	icon = 'icons/turf/walls/solid_wall_reinforced.dmi'
+	icon_state = "wall-0"
+	base_icon_state = "wall"
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SHUTTERS_BLASTDOORS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_LOW_WALL)
 
+	reinf_material = /datum/material/iron
+	plating_material = /datum/material/alloy/plasteel
 
-/turf/closed/indestructible/riveted
-	icon = 'icons/turf/walls/legacy/riveted.dmi'
-	icon_state = "riveted-0"
-	base_icon_state = "riveted"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS)
-	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
-
-/turf/closed/indestructible/syndicate
-	icon = 'icons/turf/walls/legacy/plastitanium_wall.dmi'
-	icon_state = "plastitanium_wall-0"
-	base_icon_state = "plastitanium_wall"
+/turf/closed/wall/indestructible/reinforced/syndicate
+	icon = 'icons/turf/walls/metal_wall.dmi'
+	icon_state = "wall-0"
+	base_icon_state = "wall"
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
 
-/turf/closed/indestructible/riveted/uranium
+	reinf_material = /datum/material/iron
+	plating_material = /datum/material/alloy/plastitanium
+	color = "#3a313a" //To display in mapping softwares
+
+/turf/closed/wall/indestructible/reinforced/uranium
 	icon = 'icons/turf/walls/legacy/uranium_wall.dmi'
 	icon_state = "uranium_wall-0"
 	base_icon_state = "uranium_wall"
 	smoothing_flags = SMOOTH_BITMASK
 
-/turf/closed/indestructible/riveted/plastinum
+/turf/closed/wall/indestructible/reinforced/plastinum
 	name = "plastinum wall"
 	desc = "A luxurious wall made out of a plasma-platinum alloy. Effectively impervious to conventional methods of destruction."
 	icon = 'icons/turf/walls/legacy/plastinum_wall.dmi'
 	icon_state = "plastinum_wall-0"
 	base_icon_state = "plastinum_wall"
-
-/turf/closed/indestructible/wood
-	icon = 'icons/turf/walls/legacy/wood_wall.dmi'
-	icon_state = "wood_wall-0"
-	base_icon_state = "wood_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-
-
-/turf/closed/indestructible/alien
-	name = "alien wall"
-	desc = "A wall with alien alloy plating."
-	icon = 'icons/turf/walls/legacy/abductor_wall.dmi'
-	icon_state = "abductor_wall-0"
-	base_icon_state = "abductor_wall"
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-
-
-/turf/closed/indestructible/cult
-	name = "runed metal wall"
-	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/legacy/cult_wall.dmi'
-	icon_state = "cult_wall-0"
-	base_icon_state = "cult_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-
 
 /turf/closed/indestructible/abductor
 	icon_state = "alien1"
@@ -201,97 +313,3 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	icon_state = null
 	underlays += mutable_appearance('icons/obj/structures.dmi', "grille")
 	underlays += mutable_appearance('icons/turf/floors.dmi', "plating")
-
-/turf/closed/indestructible/fakedoor
-	name = "CentCom Access"
-	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
-	icon_state = "fake_door"
-
-/turf/closed/indestructible/rock
-	name = "dense rock"
-	desc = "An extremely densely-packed rock, most mining tools or explosives would never get through this."
-	icon = 'icons/turf/mining.dmi'
-	icon_state = "rock"
-
-/turf/closed/indestructible/rock/snow
-	name = "mountainside"
-	desc = "An extremely densely-packed rock, sheeted over with centuries worth of ice and snow."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "snowrock"
-	bullet_sizzle = TRUE
-	bullet_bounce_sound = null
-
-/turf/closed/indestructible/rock/snow/ice
-	name = "iced rock"
-	desc = "Extremely densely-packed sheets of ice and rock, forged over the years of the harsh cold."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "icerock"
-
-/turf/closed/indestructible/rock/snow/ice/ore
-	icon = 'icons/turf/walls/legacy/icerock_wall.dmi'
-	icon_state = "icerock_wall-0"
-	base_icon_state = "icerock_wall"
-	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
-	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
-	pixel_x = -4
-	pixel_y = -4
-
-
-/turf/closed/indestructible/paper
-	name = "thick paper wall"
-	desc = "A wall layered with impenetrable sheets of paper."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "paperwall"
-
-/turf/closed/indestructible/necropolis
-	name = "necropolis wall"
-	desc = "A seemingly impenetrable wall."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "necro"
-	explosion_block = 50
-	baseturfs = /turf/closed/indestructible/necropolis
-
-/turf/closed/indestructible/necropolis/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "necro1"
-	return TRUE
-
-/turf/closed/indestructible/iron
-	name = "impervious iron wall"
-	desc = "A wall with tough iron plating."
-	icon = 'icons/turf/walls/legacy/iron_wall.dmi'
-	icon_state = "iron_wall-0"
-	base_icon_state = "iron_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-	opacity = FALSE
-
-/turf/closed/indestructible/riveted/boss
-	name = "necropolis wall"
-	desc = "A thick, seemingly indestructible stone wall."
-	icon = 'icons/turf/walls/legacy/boss_wall.dmi'
-	icon_state = "boss_wall-0"
-	base_icon_state = "boss_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_BOSS_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_BOSS_WALLS)
-	explosion_block = 50
-	baseturfs = /turf/closed/indestructible/riveted/boss
-
-/turf/closed/indestructible/riveted/boss/see_through
-	opacity = FALSE
-
-/turf/closed/indestructible/riveted/boss/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "basalt"
-	return TRUE
-
-/turf/closed/indestructible/riveted/hierophant
-	name = "wall"
-	desc = "A wall made out of a strange metal. The squares on it pulse in a predictable pattern."
-	icon = 'icons/turf/walls/legacy/hierophant_wall.dmi'
-	icon_state = "wall"
-	smoothing_flags = SMOOTH_CORNERS
-	smoothing_groups = list(SMOOTH_GROUP_HIERO_WALL)
-	canSmoothWith = list(SMOOTH_GROUP_HIERO_WALL)

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -266,9 +266,9 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	color = "#3a313a" //To display in mapping softwares
 
 /turf/closed/wall/indestructible/reinforced/uranium
-	icon = 'icons/turf/walls/legacy/uranium_wall.dmi'
 	smoothing_flags = SMOOTH_BITMASK
-	color = "#30f71a" //To display in mapping softwares
+	plating_material = /datum/material/uranium
+	color = "#30ed1a" //To display in mapping softwares
 
 /turf/closed/wall/indestructible/reinforced/plastinum
 	name = "plastinum wall"

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -242,6 +242,13 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 /turf/closed/indestructible/singularity_act()
 	return
 
+/turf/closed/wall/indestructible/uranium
+	icon = 'icons/turf/walls/stone_wall.dmi'
+	desc = "A wall with uranium plating. This is probably a bad idea. Effectively impervious to conventional methods of destruction."
+	smoothing_flags = SMOOTH_BITMASK
+	plating_material = /datum/material/uranium
+	color = "#007a00" //To display in mapping softwares
+
 /turf/closed/wall/indestructible/reinforced
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
@@ -264,11 +271,6 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	reinf_material = /datum/material/iron
 	plating_material = /datum/material/alloy/plastitanium
 	color = "#3a313a" //To display in mapping softwares
-
-/turf/closed/wall/indestructible/reinforced/uranium
-	smoothing_flags = SMOOTH_BITMASK
-	plating_material = /datum/material/uranium
-	color = "#30ed1a" //To display in mapping softwares
 
 /turf/closed/wall/indestructible/reinforced/plastinum
 	name = "plastinum wall"

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -58,6 +58,12 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_WALLS)
 
+/turf/closed/indestructible/abductor
+	icon_state = "alien1"
+
+/turf/closed/indestructible/opshuttle
+	icon_state = "wall3"
+
 /turf/closed/indestructible/cult
 	name = "runed metal wall"
 	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound. Effectively impervious to conventional methods of destruction."
@@ -251,8 +257,6 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 
 /turf/closed/wall/indestructible/reinforced/syndicate
 	icon = 'icons/turf/walls/metal_wall.dmi'
-	icon_state = "wall-0"
-	base_icon_state = "wall"
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
@@ -263,23 +267,13 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 
 /turf/closed/wall/indestructible/reinforced/uranium
 	icon = 'icons/turf/walls/legacy/uranium_wall.dmi'
-	icon_state = "uranium_wall-0"
-	base_icon_state = "uranium_wall"
 	smoothing_flags = SMOOTH_BITMASK
+	color = "#30f71a" //To display in mapping softwares
 
 /turf/closed/wall/indestructible/reinforced/plastinum
 	name = "plastinum wall"
 	desc = "A luxurious wall made out of a plasma-platinum alloy. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/legacy/plastinum_wall.dmi'
-	icon_state = "plastinum_wall-0"
-	base_icon_state = "plastinum_wall"
-
-/turf/closed/indestructible/abductor
-	icon_state = "alien1"
-
-/turf/closed/indestructible/opshuttle
-	icon_state = "wall3"
-
+	color = "#b3c0c7" //To display in mapping softwares
 
 /turf/closed/indestructible/fakeglass
 	name = "window"

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -226,20 +226,20 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
 	explosion_block = 50
 
-/turf/closed/indestructible/rust_heretic_act()
+/turf/closed/wall/indestructible/rust_heretic_act()
 	return
 
-/turf/closed/indestructible/TerraformTurf(path, new_baseturf, flags, defer_change = FALSE, ignore_air = FALSE)
+/turf/closed/wall/indestructible/TerraformTurf(path, new_baseturf, flags, defer_change = FALSE, ignore_air = FALSE)
 	return
 
-/turf/closed/indestructible/acid_act(acidpwr, acid_volume, acid_id)
+/turf/closed/wall/indestructible/acid_act(acidpwr, acid_volume, acid_id)
 	return FALSE
 
-/turf/closed/indestructible/Melt()
+/turf/closed/wall/indestructible/Melt()
 	to_be_destroyed = FALSE
 	return src
 
-/turf/closed/indestructible/singularity_act()
+/turf/closed/wall/indestructible/singularity_act()
 	return
 
 /turf/closed/wall/indestructible/uranium

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -48,8 +48,9 @@
 	article = "a"
 	name = "uranium wall"
 	desc = "A wall with uranium plating. This is probably a bad idea."
+	icon = 'icons/turf/walls/stone_wall.dmi'
 	plating_material = /datum/material/uranium
-	color = "#30f71a" //To display in mapping softwares
+	color = "#007a00" //To display in mapping softwares
 
 /turf/closed/wall/mineral/uranium/proc/radiate()
 	if(!active)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Converts some indestructible walls to the new greyscaled baywalls, fixes stuff like the luxury shuttle looking a bit wonky.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Centcom and Syndicate base walls (and some other indestructible subtypes) look better now.
code: Changes the color of the uranium material to be a less eye hurting green.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
